### PR TITLE
Create cbor_decoptions.svg

### DIFF
--- a/cbor/v2.2.0/cbor_decoptions.svg
+++ b/cbor/v2.2.0/cbor_decoptions.svg
@@ -1,0 +1,404 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="746"
+   height="320"
+   viewBox="0 0 197.37917 84.666665"
+   version="1.1"
+   id="svg919"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="cbor_decoptions.svg">
+  <defs
+     id="defs913" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="-583.08517"
+     inkscape:cy="90.764501"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1385"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata916">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-212.33335)">
+    <rect
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       y="246.9628"
+       x="-248.37929"
+       height="10.29295"
+       width="214.03244"
+       id="rect4780"
+       style="opacity:1;fill:#eef2ff;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="267.33881"
+       x="-248.37929"
+       height="10.29295"
+       width="214.03242"
+       id="rect7535"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016" />
+    <rect
+       y="277.65839"
+       x="-248.37929"
+       height="10.29295"
+       width="214.03242"
+       id="rect7537"
+       style="opacity:1;fill:#f6f8fa;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016" />
+    <rect
+       y="287.978"
+       x="-248.37929"
+       height="10.29295"
+       width="214.03242"
+       id="rect7539"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016" />
+    <rect
+       y="298.29758"
+       x="-248.37929"
+       height="10.29295"
+       width="214.03242"
+       id="rect7541"
+       style="opacity:1;fill:#f6f8fa;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016" />
+    <rect
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7543"
+       width="214.03242"
+       height="10.29295"
+       x="-248.37929"
+       y="308.61716" />
+    <rect
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       style="opacity:1;fill:#f6f8fa;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26453888;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect7545"
+       width="214.03235"
+       height="10.378316"
+       x="-248.37935"
+       y="318.8938" />
+    <rect
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       style="opacity:1;fill:#f6f8fa;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4784"
+       width="214.03242"
+       height="10.29295"
+       x="-248.37929"
+       y="257.01923" />
+    <text
+       id="text4788"
+       y="253.88327"
+       x="-238.5773"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       xml:space="preserve"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016"
+       transform="scale(1.0000084,0.9999916)"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23329735px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"
+         y="253.88327"
+         x="-238.5773"
+         id="tspan4786"
+         sodipodi:role="line">DecOptions</tspan></text>
+    <text
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       x="-162.52676"
+       y="253.88327"
+       id="text4811"
+       transform="scale(1.0000084,0.9999916)"><tspan
+         sodipodi:role="line"
+         id="tspan4809"
+         x="-162.52676"
+         y="253.88327"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23329735px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108">Available Settings (defaults in bold+green)</tspan></text>
+    <rect
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       y="246.86258"
+       x="-200.07915"
+       height="82.472275"
+       width="0.22377366"
+       id="rect7555"
+       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.03621126;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <text
+       transform="scale(1.0000084,0.9999916)"
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       x="-244.60559"
+       y="263.78058"
+       id="text7563"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016"><tspan
+         sodipodi:role="line"
+         id="tspan7561"
+         x="-244.60559"
+         y="263.78058"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108">TimeTag</tspan></text>
+    <text
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       id="text7571"
+       y="263.88348"
+       x="-195.33487"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       xml:space="preserve"
+       transform="scale(1.0000084,0.9999916)"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"
+         y="263.88348"
+         x="-195.33487"
+         id="tspan7569"
+         sodipodi:role="line"><tspan
+           style="fill:#008000;stroke-width:0.26458108"
+           id="tspan1686">DecTagIgnored</tspan><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;stroke-width:0.26458108"
+           id="tspan1654">, DecTagOptional, DecTagRequired</tspan></tspan></text>
+    <text
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       id="text7575"
+       y="274.24451"
+       x="-244.60559"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       xml:space="preserve"
+       transform="scale(1.0000084,0.9999916)"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108"
+         y="274.24451"
+         x="-244.60559"
+         id="tspan7573"
+         sodipodi:role="line">DupMapKey</tspan></text>
+    <text
+       transform="scale(1.0000084,0.9999916)"
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       x="-195.33487"
+       y="274.42416"
+       id="text7583"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016"><tspan
+         sodipodi:role="line"
+         id="tspan7581"
+         x="-195.33487"
+         y="274.42416"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"><tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
+   id="tspan1656">DupMapKeyQuiet</tspan>, DupMapKeyEnforcedAPF</tspan></text>
+    <text
+       transform="scale(1.0000084,0.9999916)"
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       x="-244.63593"
+       y="294.52609"
+       id="text7587"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016"><tspan
+         sodipodi:role="line"
+         id="tspan7585"
+         x="-244.63593"
+         y="294.52609"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108">TagsMd</tspan></text>
+    <text
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       id="text7595"
+       y="294.68872"
+       x="-195.33487"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       xml:space="preserve"
+       transform="scale(1.0000084,0.9999916)"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"
+         y="294.68872"
+         x="-195.33487"
+         id="tspan7593"
+         sodipodi:role="line"><tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
+   id="tspan1660">TagsAllowed</tspan>, TagsForbidden</tspan></text>
+    <text
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       id="text7599"
+       y="304.85352"
+       x="-244.40317"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       xml:space="preserve"
+       transform="scale(1.0000084,0.9999916)"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108"
+         y="304.85352"
+         x="-244.40317"
+         id="tspan7597"
+         sodipodi:role="line">MaxNestedLevels</tspan></text>
+    <text
+       transform="scale(1.0000084,0.9999916)"
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       x="-195.33487"
+       y="304.9874"
+       id="text7607"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016"><tspan
+         sodipodi:role="line"
+         id="tspan7605"
+         x="-195.33487"
+         y="304.9874"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"><tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
+   id="tspan1662">32</tspan>, can be set to [4, 256]</tspan></text>
+    <text
+       transform="scale(1.0000084,0.9999916)"
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       x="-244.60559"
+       y="315.13779"
+       id="text7611"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016"><tspan
+         sodipodi:role="line"
+         id="tspan7609"
+         x="-244.60559"
+         y="315.13779"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108">MaxArrayElements</tspan></text>
+    <text
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       id="text7619"
+       y="315.27438"
+       x="-195.33487"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       xml:space="preserve"
+       transform="scale(1.0000084,0.9999916)"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"
+         y="315.27438"
+         x="-195.33487"
+         id="tspan7617"
+         sodipodi:role="line"><tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
+   id="tspan1664">131072</tspan>, can be set to [16, 134217728]</tspan></text>
+    <text
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       id="text7623"
+       y="325.53912"
+       x="-244.45377"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       xml:space="preserve"
+       transform="scale(1.0000084,0.9999916)"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108"
+         y="325.53912"
+         x="-244.45377"
+         id="tspan7621"
+         sodipodi:role="line">MaxMapPairs</tspan></text>
+    <text
+       transform="scale(1.0000084,0.9999916)"
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       x="-195.33487"
+       y="325.80383"
+       id="text7631"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016"><tspan
+         sodipodi:role="line"
+         id="tspan7629"
+         x="-195.33487"
+         y="325.80383"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"><tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
+   id="tspan1666">131072</tspan>, can be set to [16, 134217728]</tspan></text>
+    <text
+       inkscape:export-ydpi="96.00016"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       id="text7683"
+       y="284.36703"
+       x="-244.60559"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       xml:space="preserve"
+       transform="scale(1.0000084,0.9999916)"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108"
+         y="284.36703"
+         x="-244.60559"
+         id="tspan7681"
+         sodipodi:role="line">IndefLength</tspan></text>
+    <text
+       transform="scale(1.0000084,0.9999916)"
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
+       x="-195.33487"
+       y="284.40155"
+       id="text7691"
+       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
+       inkscape:export-xdpi="96.00016"
+       inkscape:export-ydpi="96.00016"><tspan
+         sodipodi:role="line"
+         id="tspan7689"
+         x="-195.33487"
+         y="284.40155"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"><tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
+   id="tspan1658">IndefLengthAllowed</tspan>, IndefLengthForbidden</tspan></text>
+  </g>
+</svg>

--- a/cbor/v2.2.0/cbor_decoptions.svg
+++ b/cbor/v2.2.0/cbor_decoptions.svg
@@ -1,404 +1,58 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="746"
-   height="320"
-   viewBox="0 0 197.37917 84.666665"
-   version="1.1"
-   id="svg919"
-   inkscape:version="0.92.4 (unknown)"
-   sodipodi:docname="cbor_decoptions.svg">
-  <defs
-     id="defs913" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.98994949"
-     inkscape:cx="-583.08517"
-     inkscape:cy="90.764501"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="1385"
-     inkscape:window-x="0"
-     inkscape:window-y="31"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata916">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-212.33335)">
-    <rect
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       y="246.9628"
-       x="-248.37929"
-       height="10.29295"
-       width="214.03244"
-       id="rect4780"
-       style="opacity:1;fill:#eef2ff;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <rect
-       y="267.33881"
-       x="-248.37929"
-       height="10.29295"
-       width="214.03242"
-       id="rect7535"
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016" />
-    <rect
-       y="277.65839"
-       x="-248.37929"
-       height="10.29295"
-       width="214.03242"
-       id="rect7537"
-       style="opacity:1;fill:#f6f8fa;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016" />
-    <rect
-       y="287.978"
-       x="-248.37929"
-       height="10.29295"
-       width="214.03242"
-       id="rect7539"
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016" />
-    <rect
-       y="298.29758"
-       x="-248.37929"
-       height="10.29295"
-       width="214.03242"
-       id="rect7541"
-       style="opacity:1;fill:#f6f8fa;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016" />
-    <rect
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect7543"
-       width="214.03242"
-       height="10.29295"
-       x="-248.37929"
-       y="308.61716" />
-    <rect
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       style="opacity:1;fill:#f6f8fa;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26453888;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect7545"
-       width="214.03235"
-       height="10.378316"
-       x="-248.37935"
-       y="318.8938" />
-    <rect
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       style="opacity:1;fill:#f6f8fa;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.26458332;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4784"
-       width="214.03242"
-       height="10.29295"
-       x="-248.37929"
-       y="257.01923" />
-    <text
-       id="text4788"
-       y="253.88327"
-       x="-238.5773"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       xml:space="preserve"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016"
-       transform="scale(1.0000084,0.9999916)"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23329735px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"
-         y="253.88327"
-         x="-238.5773"
-         id="tspan4786"
-         sodipodi:role="line">DecOptions</tspan></text>
-    <text
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       x="-162.52676"
-       y="253.88327"
-       id="text4811"
-       transform="scale(1.0000084,0.9999916)"><tspan
-         sodipodi:role="line"
-         id="tspan4809"
-         x="-162.52676"
-         y="253.88327"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23329735px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108">Available Settings (defaults in bold+green)</tspan></text>
-    <rect
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       y="246.86258"
-       x="-200.07915"
-       height="82.472275"
-       width="0.22377366"
-       id="rect7555"
-       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#e0e0e0;stroke-width:0.03621126;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <text
-       transform="scale(1.0000084,0.9999916)"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       x="-244.60559"
-       y="263.78058"
-       id="text7563"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016"><tspan
-         sodipodi:role="line"
-         id="tspan7561"
-         x="-244.60559"
-         y="263.78058"
-         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108">TimeTag</tspan></text>
-    <text
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       id="text7571"
-       y="263.88348"
-       x="-195.33487"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       xml:space="preserve"
-       transform="scale(1.0000084,0.9999916)"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"
-         y="263.88348"
-         x="-195.33487"
-         id="tspan7569"
-         sodipodi:role="line"><tspan
-           style="fill:#008000;stroke-width:0.26458108"
-           id="tspan1686">DecTagIgnored</tspan><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;stroke-width:0.26458108"
-           id="tspan1654">, DecTagOptional, DecTagRequired</tspan></tspan></text>
-    <text
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       id="text7575"
-       y="274.24451"
-       x="-244.60559"
-       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       xml:space="preserve"
-       transform="scale(1.0000084,0.9999916)"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108"
-         y="274.24451"
-         x="-244.60559"
-         id="tspan7573"
-         sodipodi:role="line">DupMapKey</tspan></text>
-    <text
-       transform="scale(1.0000084,0.9999916)"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       x="-195.33487"
-       y="274.42416"
-       id="text7583"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016"><tspan
-         sodipodi:role="line"
-         id="tspan7581"
-         x="-195.33487"
-         y="274.42416"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"><tspan
-   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
-   id="tspan1656">DupMapKeyQuiet</tspan>, DupMapKeyEnforcedAPF</tspan></text>
-    <text
-       transform="scale(1.0000084,0.9999916)"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       x="-244.63593"
-       y="294.52609"
-       id="text7587"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016"><tspan
-         sodipodi:role="line"
-         id="tspan7585"
-         x="-244.63593"
-         y="294.52609"
-         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108">TagsMd</tspan></text>
-    <text
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       id="text7595"
-       y="294.68872"
-       x="-195.33487"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       xml:space="preserve"
-       transform="scale(1.0000084,0.9999916)"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"
-         y="294.68872"
-         x="-195.33487"
-         id="tspan7593"
-         sodipodi:role="line"><tspan
-   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
-   id="tspan1660">TagsAllowed</tspan>, TagsForbidden</tspan></text>
-    <text
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       id="text7599"
-       y="304.85352"
-       x="-244.40317"
-       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       xml:space="preserve"
-       transform="scale(1.0000084,0.9999916)"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108"
-         y="304.85352"
-         x="-244.40317"
-         id="tspan7597"
-         sodipodi:role="line">MaxNestedLevels</tspan></text>
-    <text
-       transform="scale(1.0000084,0.9999916)"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       x="-195.33487"
-       y="304.9874"
-       id="text7607"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016"><tspan
-         sodipodi:role="line"
-         id="tspan7605"
-         x="-195.33487"
-         y="304.9874"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"><tspan
-   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
-   id="tspan1662">32</tspan>, can be set to [4, 256]</tspan></text>
-    <text
-       transform="scale(1.0000084,0.9999916)"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       x="-244.60559"
-       y="315.13779"
-       id="text7611"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016"><tspan
-         sodipodi:role="line"
-         id="tspan7609"
-         x="-244.60559"
-         y="315.13779"
-         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108">MaxArrayElements</tspan></text>
-    <text
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       id="text7619"
-       y="315.27438"
-       x="-195.33487"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       xml:space="preserve"
-       transform="scale(1.0000084,0.9999916)"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"
-         y="315.27438"
-         x="-195.33487"
-         id="tspan7617"
-         sodipodi:role="line"><tspan
-   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
-   id="tspan1664">131072</tspan>, can be set to [16, 134217728]</tspan></text>
-    <text
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       id="text7623"
-       y="325.53912"
-       x="-244.45377"
-       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       xml:space="preserve"
-       transform="scale(1.0000084,0.9999916)"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108"
-         y="325.53912"
-         x="-244.45377"
-         id="tspan7621"
-         sodipodi:role="line">MaxMapPairs</tspan></text>
-    <text
-       transform="scale(1.0000084,0.9999916)"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       x="-195.33487"
-       y="325.80383"
-       id="text7631"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016"><tspan
-         sodipodi:role="line"
-         id="tspan7629"
-         x="-195.33487"
-         y="325.80383"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"><tspan
-   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
-   id="tspan1666">131072</tspan>, can be set to [16, 134217728]</tspan></text>
-    <text
-       inkscape:export-ydpi="96.00016"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       id="text7683"
-       y="284.36703"
-       x="-244.60559"
-       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       xml:space="preserve"
-       transform="scale(1.0000084,0.9999916)"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#4d4d4d;stroke-width:0.26458108"
-         y="284.36703"
-         x="-244.60559"
-         id="tspan7681"
-         sodipodi:role="line">IndefLength</tspan></text>
-    <text
-       transform="scale(1.0000084,0.9999916)"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93884563px;line-height:23.99999946%;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;stroke-width:0.26458108"
-       x="-195.33487"
-       y="284.40155"
-       id="text7691"
-       inkscape:export-filename="/home/guest/Desktop/cbor/cbor_safety_comparison_v2.2.png"
-       inkscape:export-xdpi="96.00016"
-       inkscape:export-ydpi="96.00016"><tspan
-         sodipodi:role="line"
-         id="tspan7689"
-         x="-195.33487"
-         y="284.40155"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.14513874px;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#333333;stroke-width:0.26458108"><tspan
-   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif;fill:#008000;stroke-width:0.26458108"
-   id="tspan1658">IndefLengthAllowed</tspan>, IndefLengthForbidden</tspan></text>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="810" height="312" viewBox="0 0 214.313 82.55">
+  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132.108h214.032v10.293H.132z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 20.484h214.032v10.293H.132z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 30.804h214.032v10.293H.132z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 41.124h214.032v10.293H.132z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 51.443h214.032v10.293H.132z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 61.763h214.032v10.293H.132z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 72.039h214.032v10.378H.132zM.132 10.165h214.032v10.293H.132z"/>
+  <text y="221.479" x="9.932" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="221.479" x="9.932" font-size="4.233">DecOptions</tspan>
+  </text>
+  <text style="line-height:23.99999946%" x="85.983" y="221.479" transform="matrix(1 0 0 1 0 -214.45)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="85.983" y="221.479" font-size="4.233">Available Settings (defaults in bold+green)</tspan>
+  </text>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".036" stroke-linejoin="round" d="M48.432.008h.224V82.48h-.224z"/>
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="3.904" y="231.376" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="3.904" y="231.376" font-size="4.145" fill="#4d4d4d">TimeTag</tspan>
+  </text>
+  <text y="231.479" x="53.175" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="231.479" x="53.175" font-size="4.145"><tspan fill="green">DecTagIgnored</tspan><tspan font-weight="400">, DecTagOptional, DecTagRequired</tspan></tspan>
+  </text>
+  <text y="241.84" x="3.904" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="241.84" x="3.904" font-size="4.145" fill="#4d4d4d">DupMapKey</tspan>
+  </text>
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="242.02" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="53.175" y="242.02" font-size="4.145"><tspan font-weight="700" fill="green">DupMapKeyQuiet</tspan>, DupMapKeyEnforcedAPF</tspan>
+  </text>
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="3.874" y="262.121" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="3.874" y="262.121" font-size="4.145" fill="#4d4d4d">TagsMd</tspan>
+  </text>
+  <text y="262.284" x="53.175" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="262.284" x="53.175" font-size="4.145"><tspan font-weight="700" fill="green">TagsAllowed</tspan>, TagsForbidden</tspan>
+  </text>
+  <text y="272.449" x="4.106" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+    <tspan y="272.449" x="4.106" font-size="4.145">MaxNestedLevels</tspan>
+  </text>
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="272.583" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="53.175" y="272.583" font-size="4.145"><tspan font-weight="700" fill="green">32</tspan>, can be set to [4, 256]</tspan>
+  </text>
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="3.904" y="282.733" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+    <tspan x="3.904" y="282.733" font-size="4.145">MaxArrayElements</tspan>
+  </text>
+  <text y="282.87" x="53.175" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="282.87" x="53.175" font-size="4.145"><tspan font-weight="700" fill="green">131072</tspan>, can be set to [16, 134217728]</tspan>
+  </text>
+  <text y="293.134" x="4.056" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+    <tspan y="293.134" x="4.056" font-size="4.145">MaxMapPairs</tspan>
+  </text>
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="293.399" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="53.175" y="293.399" font-size="4.145"><tspan font-weight="700" fill="green">131072</tspan>, can be set to [16, 134217728]</tspan>
+  </text>
+  <text y="251.962" x="3.904" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="251.962" x="3.904" font-size="4.145" fill="#4d4d4d">IndefLength</tspan>
+  </text>
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="251.997" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="53.175" y="251.997" font-size="4.145"><tspan font-weight="700" fill="green">IndefLengthAllowed</tspan>, IndefLengthForbidden</tspan>
+  </text>
 </svg>


### PR DESCRIPTION
This replaces the Decoding Options markdown table with svg.

font-family:SF Pro Text, Helvetica Neue, Segoe UI, Roboto, Liberation Sans, Arial, san-serif