### PR TITLE
Update cbor_decoptions.svg and cbor_encoptions.svg

### DIFF
--- a/cbor/v2.2.0/cbor_decoptions.svg
+++ b/cbor/v2.2.0/cbor_decoptions.svg
@@ -6,53 +6,53 @@
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 51.443h214.032v10.293H.132z"/>
   <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 61.763h214.032v10.293H.132z"/>
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 72.039h214.032v10.378H.132zM.132 10.165h214.032v10.293H.132z"/>
-  <text y="221.479" x="9.932" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="221.479" x="9.932" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="221.479" x="9.932" font-size="4.233">DecOptions</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="85.983" y="221.479" transform="matrix(1 0 0 1 0 -214.45)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text style="line-height:23.99999946%" x="85.983" y="221.479" transform="matrix(1 0 0 1 0 -214.45)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="85.983" y="221.479" font-size="4.233">Available Settings (defaults in bold+green)</tspan>
   </text>
   <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".036" stroke-linejoin="round" d="M48.432.008h.224V82.48h-.224z"/>
-  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="3.904" y="231.376" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="3.904" y="231.376" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="3.904" y="231.376" font-size="4.145" fill="#4d4d4d">TimeTag</tspan>
   </text>
-  <text y="231.479" x="53.175" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="231.479" x="53.175" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="231.479" x="53.175" font-size="4.145"><tspan fill="green">DecTagIgnored</tspan><tspan font-weight="400">, DecTagOptional, DecTagRequired</tspan></tspan>
   </text>
-  <text y="241.84" x="3.904" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="241.84" x="3.904" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="241.84" x="3.904" font-size="4.145" fill="#4d4d4d">DupMapKey</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="242.02" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="242.02" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="53.175" y="242.02" font-size="4.145"><tspan font-weight="700" fill="green">DupMapKeyQuiet</tspan>, DupMapKeyEnforcedAPF</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="3.874" y="262.121" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="3.874" y="262.121" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="3.874" y="262.121" font-size="4.145" fill="#4d4d4d">TagsMd</tspan>
   </text>
-  <text y="262.284" x="53.175" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="262.284" x="53.175" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="262.284" x="53.175" font-size="4.145"><tspan font-weight="700" fill="green">TagsAllowed</tspan>, TagsForbidden</tspan>
   </text>
-  <text y="272.449" x="4.106" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+  <text y="272.449" x="4.106" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
     <tspan y="272.449" x="4.106" font-size="4.145">MaxNestedLevels</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="272.583" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="272.583" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="53.175" y="272.583" font-size="4.145"><tspan font-weight="700" fill="green">32</tspan>, can be set to [4, 256]</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="3.904" y="282.733" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="3.904" y="282.733" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
     <tspan x="3.904" y="282.733" font-size="4.145">MaxArrayElements</tspan>
   </text>
-  <text y="282.87" x="53.175" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="282.87" x="53.175" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="282.87" x="53.175" font-size="4.145"><tspan font-weight="700" fill="green">131072</tspan>, can be set to [16, 134217728]</tspan>
   </text>
-  <text y="293.134" x="4.056" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+  <text y="293.134" x="4.056" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
     <tspan y="293.134" x="4.056" font-size="4.145">MaxMapPairs</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="293.399" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="293.399" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="53.175" y="293.399" font-size="4.145"><tspan font-weight="700" fill="green">131072</tspan>, can be set to [16, 134217728]</tspan>
   </text>
-  <text y="251.962" x="3.904" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="251.962" x="3.904" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -214.45)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="251.962" x="3.904" font-size="4.145" fill="#4d4d4d">IndefLength</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="251.997" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -214.45)" style="line-height:23.99999946%" x="53.175" y="251.997" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="53.175" y="251.997" font-size="4.145"><tspan font-weight="700" fill="green">IndefLengthAllowed</tspan>, IndefLengthForbidden</tspan>
   </text>
 </svg>

--- a/cbor/v2.2.0/cbor_encoptions.svg
+++ b/cbor/v2.2.0/cbor_encoptions.svg
@@ -8,62 +8,62 @@
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.138 89.535H214.17v10.378H.138z"/>
   <path fill="#fff" stroke="#e0e0e0" stroke-width=".254" stroke-linejoin="round" d="M.133 10.446h213.952V27.8H.133z"/>
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.138 27.66H214.17v10.293H.138z"/>
-  <text y="204.049" x="6.763" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="204.049" x="6.763" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="204.049" x="6.763" font-size="4.233">EncOptions</tspan>
   </text>
-  <text y="217.651" x="4.005" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="217.651" x="4.005" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="217.651" x="4.005" font-size="4.145" fill="#4d4d4d">Sort</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="80.697" y="204.049" transform="matrix(1 0 0 1 0 -196.988)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text style="line-height:23.99999946%" x="80.697" y="204.049" transform="matrix(1 0 0 1 0 -196.988)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="80.697" y="204.049" font-size="4.233">Available Settings (defaults in bold+green)</tspan>
   </text>
   <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".04" stroke-linejoin="round" d="M37.855.032h.224v99.944h-.224z"/>
-  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="213.417" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="213.417" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="41.539" y="213.417" font-weight="700" font-size="4.145"><tspan fill="green">SortNone</tspan><tspan font-weight="400">, SortLengthFirst, SortBytewiseLexical</tspan></tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="3.91" y="231.409" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="3.91" y="231.409" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="3.91" y="231.409" font-size="4.145" fill="#4d4d4d">Time</tspan>
   </text>
-  <text y="231.512" x="41.539" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="231.512" x="41.539" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="231.512" x="41.539" font-size="4.145"><tspan fill="green">TimeUnix</tspan><tspan font-weight="400">, TimeUnixMicro, TimeUnixDynamic, TimeRFC3339, TimeRFC3339Nano</tspan></tspan>
   </text>
-  <text y="241.873" x="3.91" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="241.873" x="3.91" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="241.873" x="3.91" font-size="4.145" fill="#4d4d4d">TimeTag</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="242.053" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="242.053" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="41.539" y="242.053" font-size="4.145"><tspan font-weight="700" fill="green">EncTagNone</tspan>, EncTagRequired</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="3.88" y="262.155" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="3.88" y="262.155" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="3.88" y="262.155" font-size="4.145" fill="#4d4d4d">InfConvert</tspan>
   </text>
-  <text y="262.317" x="41.539" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="262.317" x="41.539" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="262.317" x="41.539" font-size="4.145"><tspan font-weight="700" fill="green">InfConvertFloat16</tspan>, InfConvertNone</tspan>
   </text>
-  <text y="272.482" x="4.112" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+  <text y="272.482" x="4.112" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
     <tspan y="272.482" x="4.112" font-size="4.145">NaNConvert</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="272.616" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="272.616" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="41.539" y="272.616" font-size="4.145"><tspan font-weight="700" fill="green">NaNConvert7e00</tspan>, NaNConvertNone, NaNConvertQuiet, NaNConvertPreserveSignal</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="3.91" y="282.766" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="3.91" y="282.766" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
     <tspan x="3.91" y="282.766" font-size="4.145">IndefLength</tspan>
   </text>
-  <text y="282.903" x="41.539" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="282.903" x="41.539" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="282.903" x="41.539" font-size="4.145"><tspan font-weight="700" fill="green">IndefLengthAllowed</tspan>, IndefLengthForbidden</tspan>
   </text>
-  <text y="293.168" x="4.062" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+  <text y="293.168" x="4.062" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
     <tspan y="293.168" x="4.062" font-size="4.145">TagsMd</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="293.433" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="293.433" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="41.539" y="293.433" font-size="4.145"><tspan font-weight="700" fill="green">TagsAllowed</tspan>, TagsForbidden</tspan>
   </text>
-  <text y="251.996" x="3.91" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="251.996" x="3.91" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="251.996" x="3.91" font-size="4.145" fill="#4d4d4d">ShortestFloat</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="252.03" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text transform="matrix(1 0 0 1 0 -196.988)" style="line-height:23.99999946%" x="41.539" y="252.03" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan x="41.539" y="252.03" font-size="4.145"><tspan font-weight="700" fill="green">ShortestFloatNone</tspan>, ShortestFloat16</tspan>
   </text>
-  <text y="220.826" x="41.539" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,san-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+  <text y="220.826" x="41.539" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -196.988)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
     <tspan y="220.826" x="41.539" font-size="4.145">Aliases: SortCanonical, SortCTAP2, SortCoreDeterministic</tspan>
   </text>
 </svg>


### PR DESCRIPTION
Fix spelling of sans-serif, it was san-serif (missing 2nd s).  This caused a problem on a Linux box that didn't have Roboto and Liberation Sans.

font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Liberation Sans,Arial,sans-serif"

The source of the problem is the script I wrote this morning to modify font-family output by the vector editor (which only specifies one font for each text object).

This problem would've affected only stripped down or high security Linux distros because Liberation Sans is supposedly installed on all major Linux distros by default.