### PR TITLE
Update all svg files to reduce file size and use final font-family

### DIFF
--- a/cbor/v2.2.0/cbor_app_size_barchart.svg
+++ b/cbor/v2.2.0/cbor_app_size_barchart.svg
@@ -1,64 +1,64 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="746" height="250" viewBox="0 0 197.379 66.146">
+<svg xmlns="http://www.w3.org/2000/svg" width="746" height="250" viewBox="0 0 197.379 66.146" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
   <path fill="#fff" stroke="#fff" stroke-width=".426" d="M.213.213h196.953v65.719H.213z"/>
   <path fill="#999" stroke-width=".085" stroke-linejoin="round" d="M114.545 42.856h.265V46.1h-.265z"/>
-  <g font-weight="400" font-size="5.644" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
+  <g font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265">
     <text style="line-height:23.99999946%" x="39.632" y="235.645" transform="matrix(1 0 0 .99678 -39.588 -223.197)">
-      <tspan x="39.632" y="235.645" font-size="3.881" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#666">Same apps can be 4-9 MB smaller by using fxamacker/cbor</tspan>
+      <tspan x="39.632" y="235.645" font-size="3.881" fill="#666">Same apps can be 4-9 MB smaller by using fxamacker/cbor</tspan>
     </text>
     <text style="line-height:23.99999946%" x="39.632" y="230.308" transform="matrix(1 0 0 .99678 -39.588 -223.197)">
-      <tspan x="39.632" y="230.308" style="-inkscape-font-specification:'Inter Medium'" font-weight="500" font-size="4.233" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#333">CBOR Program Size Comparison</tspan>
+      <tspan x="39.632" y="230.308" style="-inkscape-font-specification:'Inter Medium'" font-weight="500" font-size="4.233" fill="#333">CBOR Program Size Comparison</tspan>
     </text>
-    <text style="line-height:23.99999946%" x="39.632" y="284.172" transform="matrix(1 0 0 .99678 -39.588 -223.197)">
-      <tspan x="39.632" y="284.172" font-size="3.881" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#666">MessagePack feature was removed from cisco/senml for all builds.</tspan>
+    <text style="line-height:23.99999946%" x="39.632" y="284.703" transform="matrix(1 0 0 .99678 -39.588 -223.197)">
+      <tspan x="39.632" y="284.703" font-size="3.881" fill="#666">MessagePack feature was removed from cisco/senml for all builds.</tspan>
     </text>
   </g>
-  <text style="line-height:23.99999946%" x="73.961" y="282.506" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.864" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".275">
-    <tspan x="73.961" y="282.506" font-size="3.522" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#757575">5 MB</tspan>
+  <text style="line-height:23.99999946%" x="73.961" y="282.506" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.864" letter-spacing="0" word-spacing="0" stroke-width=".275">
+    <tspan x="73.961" y="282.506" font-size="3.522" fill="#757575">5 MB</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="109.328" y="282.506" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.864" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".275">
-    <tspan x="109.328" y="282.506" font-size="3.522" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#757575">10 MB</tspan>
+  <text style="line-height:23.99999946%" x="109.328" y="282.506" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.864" letter-spacing="0" word-spacing="0" stroke-width=".275">
+    <tspan x="109.328" y="282.506" font-size="3.522" fill="#757575">10 MB</tspan>
   </text>
   <path fill="#4285f4" stroke="#fff" stroke-width=".339" d="M-62.498-360.094h3.894v3.894h-3.894z" transform="matrix(1 0 0 .99678 203.955 378.167)"/>
-  <text style="line-height:23.99999946%" x="-56.591" y="-356.793" font-weight="400" font-size="5.644" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 203.955 378.167)">
-    <tspan x="-56.591" y="-356.793" font-weight="700" font-size="4.24" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#4080ff">fxamacker/cbor 2.2</tspan>
+  <text style="line-height:23.99999946%" x="-56.591" y="-356.793" font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 203.955 378.167)">
+    <tspan x="-56.591" y="-356.793" font-weight="600" font-size="4.24" fill="#4080ff">fxamacker/cbor 2.2</tspan>
   </text>
   <path fill="#db4437" stroke="#fff" stroke-width=".339" d="M-62.272-349.472h3.894v3.894h-3.894z" transform="matrix(1 0 0 .99678 203.73 386.754)"/>
-  <text style="line-height:23.99999946%" x="-56.489" y="-346.168" font-weight="400" font-size="5.644" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 203.73 386.754)">
-    <tspan x="-56.489" y="-346.168" font-weight="700" font-size="4.24" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#c04020">ugorji/go 1.1.7</tspan>
+  <text style="line-height:23.99999946%" x="-56.489" y="-346.168" font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 203.73 386.754)">
+    <tspan x="-56.489" y="-346.168" font-weight="600" font-size="4.24" fill="#c04020">ugorji/go 1.1.7</tspan>
   </text>
-  <text transform="matrix(1.00162 0 0 .99839 -.29 -230.854)" y="259.087" x="147.087" style="line-height:1em" font-weight="400" font-size="5.635" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
+  <text transform="matrix(1.00162 0 0 .99839 -.29 -230.854)" y="259.087" x="147.087" style="line-height:1em" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
     <tspan style="line-height:50%" y="259.087" x="147.087" font-size="3.528" fill="#666">not using Go&apos;s unsafe pkg</tspan>
   </text>
-  <text transform="matrix(1.00162 0 0 .99839 -.29 -230.854)" y="263.771" x="147.056" style="line-height:1em" font-weight="400" font-size="5.635" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
-    <tspan style="line-height:50%;-inkscape-font-specification:'Open Sans'" y="263.771" x="147.056" font-size="3.528" font-family="Open Sans" fill="#666">not using code gen</tspan>
+  <text transform="matrix(1.00162 0 0 .99839 -.29 -230.854)" y="263.857" x="147.056" style="line-height:1em" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
+    <tspan style="line-height:50%" y="263.857" x="147.056" font-size="3.528" fill="#666">not using code gen</tspan>
   </text>
-  <text transform="matrix(1.00162 0 0 .99839 -.29 -230.854)" y="278.432" x="147.087" style="line-height:1em" font-weight="400" font-size="5.635" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
+  <text transform="matrix(1.00162 0 0 .99839 -.29 -230.854)" y="278.432" x="147.087" style="line-height:1em" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
     <tspan style="line-height:50%" y="278.432" x="147.087" font-size="3.528" fill="#666">using Go&apos;s unsafe pkg</tspan>
   </text>
-  <text transform="matrix(1.00162 0 0 .99839 -.29 -230.854)" y="283.203" x="147.087" style="line-height:1em" font-weight="400" font-size="5.635" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
+  <text transform="matrix(1.00162 0 0 .99839 -.29 -230.854)" y="283.203" x="147.087" style="line-height:1em" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
     <tspan style="line-height:50%" y="283.203" x="147.087" font-size="3.528" fill="#666">using code gen</tspan>
   </text>
-  <text y="242.543" x="141.313" style="line-height:23.99999946%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(-.29 -230.854)">
+  <text y="242.543" x="141.313" style="line-height:23.99999946%" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(-.29 -230.854)">
     <tspan y="242.543" x="141.313" font-size="3.881">Using default build options</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="65.185" y="253.058" font-weight="400" font-size="3.881" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -230.854)">
+  <text style="line-height:23.99999946%" x="65.185" y="253.058" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -230.854)">
     <tspan x="65.185" y="253.058" font-size="3.528" fill="gray">← 9.1 MB smaller</tspan>
   </text>
-  <text transform="matrix(1.00162 0 0 .99839 0 -230.854)" y="282.506" x="41.527" style="line-height:23.99999946%" font-weight="400" font-size="5.864" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".275">
-    <tspan y="282.506" x="41.527" font-size="3.522" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#757575">0</tspan>
+  <text transform="matrix(1.00162 0 0 .99839 0 -230.854)" y="282.506" x="41.527" style="line-height:23.99999946%" font-weight="400" font-size="5.864" letter-spacing="0" word-spacing="0" stroke-width=".275">
+    <tspan y="282.506" x="41.527" font-size="3.522" fill="#757575">0</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="40.917" y="270.021" font-weight="400" font-size="4.939" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(0 -230.854)">
+  <text style="line-height:23.99999946%" x="40.917" y="270.021" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(0 -230.854)">
     <tspan x="40.917" y="270.021" style="text-align:end" font-size="3.528" text-anchor="end" fill="#4d4d4d">senmlCat (cisco/senml)</tspan>
   </text>
-  <text y="255.533" x="40.922" style="line-height:23.99999946%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(0 -230.854)">
+  <text y="255.533" x="40.922" style="line-height:23.99999946%" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(0 -230.854)">
     <tspan style="text-align:end" y="255.533" x="40.922" font-size="3.528" text-anchor="end" fill="#4d4d4d">custom app (private)</tspan>
   </text>
   <path fill="#4285f4" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M43.008 18.765h19.94v4.915h-19.94z"/>
   <path fill="#999" stroke-width=".085" stroke-linejoin="round" d="M78.562 42.86h.265v3.24h-.265z"/>
   <path fill="#4285f4" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M42.975 33.214h54.556v4.754H42.975z"/>
-  <path fill="#db4436" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M43.008 38.042h86.146v4.688H43.008zM43.007 23.753h85.472v4.69H43.007z"/>
+  <path fill="#db4436" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M43.008 38.042h86.146v4.688H43.008zm-.001-14.289h85.472v4.69H43.007z"/>
   <path fill="#999" stroke-width=".248" stroke-linejoin="round" d="M42.578 18.633h.265V46.1h-.265z"/>
-  <text y="267.345" x="99.581" style="line-height:23.99999946%" font-weight="400" font-size="3.881" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -230.854)">
+  <text y="267.345" x="99.581" style="line-height:23.99999946%" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -230.854)">
     <tspan y="267.345" x="99.581" font-size="3.528" fill="gray">← 4.4 MB smaller</tspan>
   </text>
 </svg>

--- a/cbor/v2.2.0/cbor_decoptions.svg
+++ b/cbor/v2.2.0/cbor_decoptions.svg
@@ -1,64 +1,72 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="810" height="307" viewBox="0 0 214.313 81.227">
+<svg xmlns="http://www.w3.org/2000/svg" width="810" height="307" viewBox="0 0 214.313 81.227" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
   <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132-.003h214.032V10.29H.132z"/>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 20.21h214.032V30.5H.132z"/>
-  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 30.488h214.032V40.78H.132z"/>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 40.657h214.032V50.95H.132z"/>
-  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 50.653h214.032v10.292H.132z"/>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 60.737h214.032V71.03H.132z"/>
-  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 70.718h214.032v10.377H.132zM.132 10.206h214.032v10.292H.132z"/>
-  <text y="222.041" x="10.99" style="line-height:23.99999946%" transform="matrix(1.00007 0 0 .99993 0 -215.773)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="222.041" x="10.99" font-size="4.233">DecOptions</tspan>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 20.21h214.032V30.5H.132z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 30.488h214.032V40.78H.132z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 40.657h214.032V50.95H.132z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 50.653h214.032v10.292H.132z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 60.737h214.032V71.03H.132z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 70.718h214.032v10.377H.132zm0-60.512h214.032v10.292H.132z"/>
+  <text y="222.041" x="4.495" style="line-height:23.99999946%" transform="matrix(1.00007 0 0 .99993 0 -215.773)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="222.041" x="4.495" font-size="4.233">DecOptions</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="87.565" y="222.041" transform="matrix(1.00007 0 0 .99993 0 -215.773)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="87.565" y="222.041" font-size="4.233">Available Settings (defaults in bold+green)</tspan>
+  <text style="line-height:23.99999946%" x="56.891" y="222.041" transform="matrix(1.00007 0 0 .99993 0 -215.773)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="56.891" y="222.041" font-size="4.233">Available Settings (defaults in bold+green)</tspan>
   </text>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".036" stroke-linejoin="round" d="M52.137-.034h.224v81.191h-.224z"/>
-  <g font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text y="232.191" x="3.904" style="line-height:23.99999946%" font-weight="600" transform="matrix(1.00007 0 0 .99993 0 -215.747)">
-      <tspan y="232.191" x="3.904" font-size="4.145" fill="#4d4d4d">TimeTag</tspan>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".036" stroke-linejoin="round" d="M52.141-.033h.228v81.191h-.228z"/>
+  <g font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text y="232.218" x="4.597" style="line-height:23.99999946%" font-weight="600" transform="matrix(1.00007 0 0 .99993 0 -215.717)">
+      <tspan y="232.218" x="4.597" font-size="4.145" fill="#4d4d4d">TimeTag</tspan>
     </text>
-    <text style="line-height:23.99999946%" x="56.875" y="232.191" font-weight="700" transform="matrix(1.00007 0 0 .99993 0 -215.747)">
-      <tspan x="56.875" y="232.191" font-size="4.145"><tspan fill="green">DecTagIgnored</tspan><tspan font-weight="400">, DecTagOptional, DecTagRequired</tspan></tspan>
-    </text>
-  </g>
-  <g font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="3.904" y="242.125" font-weight="600" transform="matrix(1.00007 0 0 .99993 0 -215.667)">
-      <tspan x="3.904" y="242.125" font-size="4.145" fill="#4d4d4d">DupMapKey</tspan>
-    </text>
-    <text y="242.125" x="56.875" style="line-height:23.99999946%" font-weight="400" transform="matrix(1.00007 0 0 .99993 0 -215.667)">
-      <tspan y="242.125" x="56.875" font-size="4.145"><tspan font-weight="700" fill="green">DupMapKeyQuiet</tspan>, DupMapKeyEnforcedAPF</tspan>
+    <text style="line-height:23.99999946%" x="56.62" y="232.218" font-weight="700" transform="matrix(1.00007 0 0 .99993 0 -215.717)">
+      <tspan x="56.62" y="232.218" font-size="4.145"><tspan fill="green">DecTagIgnored</tspan><tspan font-weight="400">, DecTagOptional, DecTagRequired</tspan></tspan>
     </text>
   </g>
-  <text transform="matrix(1.00007 0 0 .99993 0 -215.773)" style="line-height:23.99999946%" x="3.873" y="262.671" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="3.873" y="262.671" font-size="4.145" fill="#4d4d4d">TagsMd</tspan>
-  </text>
-  <text y="262.671" x="56.875" style="line-height:23.99999946%" transform="matrix(1.00007 0 0 .99993 0 -215.773)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="262.671" x="56.875" font-size="4.145"><tspan font-weight="700" fill="green">TagsAllowed</tspan>, TagsForbidden</tspan>
-  </text>
-  <text y="273.145" x="4.106" style="line-height:23.99999946%" transform="matrix(1.00007 0 0 .99993 0 -215.773)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
-    <tspan y="273.145" x="4.106" font-size="4.145">MaxNestedLevels</tspan>
-  </text>
-  <text transform="matrix(1.00007 0 0 .99993 0 -215.773)" style="line-height:23.99999946%" x="56.875" y="272.837" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="56.875" y="272.837" font-size="4.145"><tspan font-weight="700" fill="green">32</tspan>, can be set to [4, 256]</tspan>
-  </text>
-  <text transform="matrix(1.00007 0 0 .99993 0 -215.773)" style="line-height:23.99999946%" x="3.904" y="282.752" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
-    <tspan x="3.904" y="282.752" font-size="4.145">MaxArrayElements</tspan>
-  </text>
-  <text y="282.922" x="56.875" style="line-height:23.99999946%" transform="matrix(1.00007 0 0 .99993 0 -215.773)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="282.922" x="56.875" font-size="4.145"><tspan font-weight="700" fill="green">131072</tspan>, can be set to [16, 134217728]</tspan>
-  </text>
-  <g font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="4.056" y="292.75" font-weight="600" fill="#4d4d4d" transform="matrix(1.00007 0 0 .99993 0 -215.747)">
-      <tspan x="4.056" y="292.75" font-size="4.145">MaxMapPairs</tspan>
+  <g font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="4.465" y="242.232" font-weight="600" transform="matrix(1.00007 0 0 .99993 0 -215.691)">
+      <tspan x="4.465" y="242.232" font-size="4.145" fill="#4d4d4d">DupMapKey</tspan>
     </text>
-    <text y="292.75" x="56.875" style="line-height:23.99999946%" font-weight="400" fill="#333" transform="matrix(1.00007 0 0 .99993 0 -215.747)">
-      <tspan y="292.75" x="56.875" font-size="4.145"><tspan font-weight="700" fill="green">131072</tspan>, can be set to [16, 134217728]</tspan>
+    <text y="242.232" x="56.62" style="line-height:23.99999946%" font-weight="400" transform="matrix(1.00007 0 0 .99993 0 -215.691)">
+      <tspan y="242.232" x="56.62" font-size="4.145"><tspan font-weight="700" fill="green">DupMapKeyQuiet</tspan><tspan>, DupMapKeyEnforcedAPF</tspan></tspan>
     </text>
   </g>
-  <text y="252.512" x="3.904" style="line-height:23.99999946%" transform="matrix(1.00007 0 0 .99993 0 -215.773)" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="252.512" x="3.904" font-size="4.145" fill="#4d4d4d">IndefLength</tspan>
-  </text>
-  <text transform="matrix(1.00007 0 0 .99993 0 -215.773)" style="line-height:23.99999946%" x="56.875" y="252.512" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="56.875" y="252.512" font-size="4.145"><tspan font-weight="700" fill="green">IndefLengthAllowed</tspan>, IndefLengthForbidden</tspan>
-  </text>
+  <g font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text y="262.671" x="4.597" style="line-height:23.99999946%" font-weight="600" transform="matrix(1.00007 0 0 .99993 0 -215.743)">
+      <tspan y="262.671" x="4.597" font-size="4.145" fill="#4d4d4d">TagsMd</tspan>
+    </text>
+    <text style="line-height:23.99999946%" x="56.909" y="262.671" font-weight="400" transform="matrix(1.00007 0 0 .99993 0 -215.743)">
+      <tspan x="56.909" y="262.671" font-size="4.145"><tspan font-weight="700" fill="green">TagsAllowed</tspan><tspan>, TagsForbidden</tspan></tspan>
+    </text>
+  </g>
+  <g font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="4.465" y="273.145" font-weight="600" fill="#4d4d4d" transform="matrix(1.00007 0 0 .99993 0 -215.692)">
+      <tspan x="4.465" y="273.145" font-size="4.145">MaxNestedLevels</tspan>
+    </text>
+    <text y="272.837" x="56.834" style="line-height:23.99999946%" font-weight="400" fill="#333" transform="matrix(1.00007 0 0 .99993 0 -215.692)">
+      <tspan y="272.837" x="56.834" font-size="4.145"><tspan font-weight="700" fill="green">32</tspan><tspan>, can be set to [4, 256]</tspan></tspan>
+    </text>
+  </g>
+  <g font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <text y="282.752" x="4.465" style="line-height:23.99999946%" font-weight="600" fill="#4d4d4d" transform="matrix(1.00007 0 0 .99993 0 -215.692)">
+      <tspan y="282.752" x="4.465" font-size="4.145">MaxArrayElements</tspan>
+    </text>
+    <text style="line-height:23.99999946%" x="56.747" y="282.922" font-weight="400" fill="#333" transform="matrix(1.00007 0 0 .99993 0 -215.692)">
+      <tspan x="56.747" y="282.922" font-size="4.145"><tspan font-weight="700" fill="green">131072</tspan><tspan>, can be set to [16, 134217728]</tspan></tspan>
+    </text>
+  </g>
+  <g font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="4.465" y="292.776" font-weight="600" fill="#4d4d4d" transform="matrix(1.00007 0 0 .99993 0 -215.578)">
+      <tspan x="4.465" y="292.776" font-size="4.145">MaxMapPairs</tspan>
+    </text>
+    <text y="292.776" x="56.747" style="line-height:23.99999946%" font-weight="400" fill="#333" transform="matrix(1.00007 0 0 .99993 0 -215.578)">
+      <tspan y="292.776" x="56.747" font-size="4.145"><tspan font-weight="700" fill="green">131072</tspan><tspan>, can be set to [16, 134217728]</tspan></tspan>
+    </text>
+  </g>
+  <g font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="4.465" y="252.512" font-weight="600" transform="matrix(1.00007 0 0 .99993 0 -215.73)">
+      <tspan x="4.465" y="252.512" font-size="4.145" fill="#4d4d4d">IndefLength</tspan>
+    </text>
+    <text y="252.512" x="56.62" style="line-height:23.99999946%" font-weight="400" transform="matrix(1.00007 0 0 .99993 0 -215.73)">
+      <tspan y="252.512" x="56.62" font-size="4.145"><tspan font-weight="700" fill="green">IndefLengthAllowed</tspan><tspan>, IndefLengthForbidden</tspan></tspan>
+    </text>
+  </g>
 </svg>

--- a/cbor/v2.2.0/cbor_encoptions.svg
+++ b/cbor/v2.2.0/cbor_encoptions.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="840" height="375" viewBox="0 0 222.25 99.219">
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="375" viewBox="0 0 222.25 99.219" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
   <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132.133h221.985V10.45H.132z"/>
   <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 37.439h221.985v10.318H.132z"/>
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 47.493h221.985V57.81H.132z"/>
@@ -8,76 +8,62 @@
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 88.768h221.986v10.319H.132z"/>
   <path fill="#fff" stroke="#e0e0e0" stroke-width=".263" stroke-linejoin="round" d="M.132 10.45h221.987v17.2H.132z"/>
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 27.385h221.985v10.318H.132z"/>
-  <text y="204.877" x="6.763" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="700" font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="204.877" x="6.763" font-size="4.233">EncOptions</tspan>
+  <text y="204.877" x="4.494" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="700" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="204.877" x="4.494" font-size="4.233">EncOptions</tspan>
   </text>
-  <text y="218.271" x="4.005" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="600" font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="218.271" x="4.005" font-size="4.145" fill="#4d4d4d">Sort</tspan>
+  <text y="218.271" x="4.574" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="600" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="218.271" x="4.574" font-size="4.145" fill="#4d4d4d">Sort</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="80.69" y="204.877" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="700" font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="80.69" y="204.877" font-size="4.233">Available Settings (defaults in bold+green)</tspan>
+  <text style="line-height:23.99999946%" x="43.551" y="204.877" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="700" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="43.551" y="204.877" font-size="4.233">Available Settings (defaults in bold+green)</tspan>
   </text>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".04" stroke-linejoin="round" d="M37.856.119h.224V99.15h-.224z"/>
-  <text transform="matrix(1.0001 0 0 .9999 0 -197.781)" style="line-height:23.99999946%" x="42.594" y="214.567" font-weight="400" font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="42.594" y="214.567" font-weight="700" font-size="4.145"><tspan fill="green">SortNone</tspan><tspan font-weight="400">, SortLengthFirst, SortBytewiseLexical</tspan></tspan>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".04" stroke-linejoin="round" d="M38.914.119h.225V99.15h-.225z"/>
+  <text transform="matrix(1.0001 0 0 .9999 0 -197.781)" style="line-height:23.99999946%" x="43.487" y="214.567" font-weight="400" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="43.487" y="214.567" font-weight="700" font-size="4.145"><tspan fill="green">SortNone</tspan><tspan font-weight="400">, SortLengthFirst, SortBytewiseLexical</tspan></tspan>
   </text>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text y="231.901" x="3.91" style="line-height:23.99999946%" font-weight="600" transform="matrix(1.0001 0 0 .9999 0 -198.258)">
-      <tspan y="231.901" x="3.91" font-size="4.145" fill="#4d4d4d">Time</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="42.594" y="231.901" font-weight="700" transform="matrix(1.0001 0 0 .9999 0 -198.258)">
-      <tspan x="42.594" y="231.901" font-size="4.145"><tspan fill="green">TimeUnix</tspan><tspan font-weight="400">, TimeUnixMicro, TimeUnixDynamic, TimeRFC3339, TimeRFC3339Nano</tspan></tspan>
-    </text>
-  </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="3.91" y="241.477" font-weight="600" transform="matrix(1.0001 0 0 .9999 0 -197.778)">
-      <tspan x="3.91" y="241.477" font-size="4.145" fill="#4d4d4d">TimeTag</tspan>
-    </text>
-    <text y="241.477" x="42.594" style="line-height:23.99999946%" font-weight="400" transform="matrix(1.0001 0 0 .9999 0 -197.778)">
-      <tspan y="241.477" x="42.594" font-size="4.145"><tspan font-weight="700" fill="green">EncTagNone</tspan>, EncTagRequired</tspan>
-    </text>
-  </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text y="262.363" x="3.88" style="line-height:23.99999946%" font-weight="600" transform="matrix(1.0001 0 0 .9999 0 -198.048)">
-      <tspan y="262.363" x="3.88" font-size="4.145" fill="#4d4d4d">InfConvert</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="42.594" y="262.363" font-weight="400" transform="matrix(1.0001 0 0 .9999 0 -198.048)">
-      <tspan x="42.594" y="262.363" font-size="4.145"><tspan font-weight="700" fill="green">InfConvertFloat16</tspan>, InfConvertNone</tspan>
-    </text>
-  </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="4.112" y="272.596" font-weight="600" fill="#4d4d4d" transform="matrix(1.0001 0 0 .9999 0 -198.185)">
-      <tspan x="4.112" y="272.596" font-size="4.145">NaNConvert</tspan>
-    </text>
-    <text y="272.596" x="42.594" style="line-height:23.99999946%" font-weight="400" fill="#333" transform="matrix(1.0001 0 0 .9999 0 -198.185)">
-      <tspan y="272.596" x="42.594" font-size="4.145"><tspan font-weight="700" fill="green">NaNConvert7e00</tspan>, NaNConvertNone, NaNConvertQuiet, NaNConvertPreserveSignal</tspan>
-    </text>
-  </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <text y="282.521" x="3.91" style="line-height:23.99999946%" font-weight="600" fill="#4d4d4d" transform="matrix(1.0001 0 0 .9999 0 -197.797)">
-      <tspan y="282.521" x="3.91" font-size="4.145">IndefLength</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="42.594" y="282.521" font-weight="400" fill="#333" transform="matrix(1.0001 0 0 .9999 0 -197.797)">
-      <tspan x="42.594" y="282.521" font-size="4.145"><tspan font-weight="700" fill="green">IndefLengthAllowed</tspan>, IndefLengthForbidden</tspan>
-    </text>
-  </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="4.062" y="293.164" font-weight="600" fill="#4d4d4d" transform="matrix(1.0001 0 0 .9999 0 -198.131)">
-      <tspan x="4.062" y="293.164" font-size="4.145">TagsMd</tspan>
-    </text>
-    <text y="293.164" x="42.594" style="line-height:23.99999946%" font-weight="400" fill="#333" transform="matrix(1.0001 0 0 .9999 0 -198.131)">
-      <tspan y="293.164" x="42.594" font-size="4.145"><tspan font-weight="700" fill="green">TagsAllowed</tspan>, TagsForbidden</tspan>
-    </text>
-  </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="3.91" y="252.034" font-weight="600" transform="matrix(1.0001 0 0 .9999 0 -198.05)">
-      <tspan x="3.91" y="252.034" font-size="4.145" fill="#4d4d4d">ShortestFloat</tspan>
-    </text>
-    <text y="252.034" x="42.594" style="line-height:23.99999946%" font-weight="400" transform="matrix(1.0001 0 0 .9999 0 -198.05)">
-      <tspan y="252.034" x="42.594" font-size="4.145"><tspan font-weight="700" fill="green">ShortestFloatNone</tspan>, ShortestFloat16</tspan>
-    </text>
-  </g>
-  <text y="221.71" x="42.594" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="400" font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="221.71" x="42.594" font-size="4.145">Aliases: SortCanonical, SortCTAP2, SortCoreDeterministic</tspan>
+  <text transform="matrix(1.0001 0 0 .9999 0 -197.781)" style="line-height:23.99999946%" x="4.597" y="231.521" font-weight="600" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="4.597" y="231.521" font-size="4.145" fill="#4d4d4d">Time</tspan>
+  </text>
+  <text y="231.521" x="43.505" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="700" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="231.521" x="43.505" font-size="4.145"><tspan fill="green">TimeUnix</tspan><tspan font-weight="400">, TimeUnixMicro, TimeUnixDynamic, TimeRFC3339, TimeRFC3339Nano</tspan></tspan>
+  </text>
+  <text y="241.536" x="4.597" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="600" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="241.536" x="4.597" font-size="4.145" fill="#4d4d4d">TimeTag</tspan>
+  </text>
+  <text transform="matrix(1.0001 0 0 .9999 0 -197.781)" style="line-height:23.99999946%" x="43.39" y="241.536" font-weight="400" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="43.39" y="241.536" font-size="4.145"><tspan font-weight="700" fill="green">EncTagNone</tspan><tspan>, EncTagRequired</tspan></tspan>
+  </text>
+  <text transform="matrix(1.0001 0 0 .9999 0 -197.781)" style="line-height:23.99999946%" x="4.465" y="261.988" font-weight="600" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="4.465" y="261.988" font-size="4.145" fill="#4d4d4d">InfConvert</tspan>
+  </text>
+  <text y="261.988" x="43.39" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="400" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="261.988" x="43.39" font-size="4.145"><tspan font-weight="700" fill="green">InfConvertFloat16</tspan><tspan>, InfConvertNone</tspan></tspan>
+  </text>
+  <text y="272.223" x="4.465" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="600" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+    <tspan y="272.223" x="4.465" font-size="4.145">NaNConvert</tspan>
+  </text>
+  <text transform="matrix(1.0001 0 0 .9999 0 -197.781)" style="line-height:23.99999946%" x="43.39" y="272.223" font-weight="400" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="43.39" y="272.223" font-size="4.145"><tspan font-weight="700" fill="green">NaNConvert7e00</tspan><tspan>, NaNConvertNone, NaNConvertQuiet, NaNConvertPreserveSignal</tspan></tspan>
+  </text>
+  <text transform="matrix(1.0001 0 0 .9999 0 -197.781)" style="line-height:23.99999946%" x="4.465" y="282.548" font-weight="600" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+    <tspan x="4.465" y="282.548" font-size="4.145">IndefLength</tspan>
+  </text>
+  <text y="282.548" x="43.39" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="400" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="282.548" x="43.39" font-size="4.145"><tspan font-weight="700" fill="green">IndefLengthAllowed</tspan><tspan>, IndefLengthForbidden</tspan></tspan>
+  </text>
+  <text y="292.845" x="4.597" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="600" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265">
+    <tspan y="292.845" x="4.597" font-size="4.145">TagsMd</tspan>
+  </text>
+  <text transform="matrix(1.0001 0 0 .9999 0 -197.781)" style="line-height:23.99999946%" x="43.24" y="292.845" font-weight="400" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="43.24" y="292.845" font-size="4.145"><tspan font-weight="700" fill="green">TagsAllowed</tspan><tspan>, TagsForbidden</tspan></tspan>
+  </text>
+  <text y="251.621" x="4.574" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="600" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="251.621" x="4.574" font-size="4.145" fill="#4d4d4d">ShortestFloat</tspan>
+  </text>
+  <text transform="matrix(1.0001 0 0 .9999 0 -197.781)" style="line-height:23.99999946%" x="43.487" y="251.621" font-weight="400" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="43.487" y="251.621" font-size="4.145"><tspan font-weight="700" fill="green">ShortestFloatNone</tspan><tspan>, ShortestFloat16</tspan></tspan>
+  </text>
+  <text y="221.71" x="43.652" style="line-height:23.99999946%" transform="matrix(1.0001 0 0 .9999 0 -197.781)" font-weight="400" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="221.71" x="43.652" font-size="4.145">Aliases: SortCanonical, SortCTAP2, SortCoreDeterministic</tspan>
   </text>
 </svg>

--- a/cbor/v2.2.0/cbor_features.svg
+++ b/cbor/v2.2.0/cbor_features.svg
@@ -1,86 +1,84 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="880" height="298" viewBox="0 0 232.833 78.846">
-  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132.132h232.525v8.73H.132z"/>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 26.326h232.525v8.73H.132z"/>
-  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 35.057h232.525v8.73H.132z"/>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 43.789h232.529v8.73H.132z"/>
-  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 52.52h232.529v8.73H.132z"/>
-  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".263" stroke-linejoin="round" d="M.132 69.982h232.53v8.732H.132z"/>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 8.864h232.525v8.73H.132z"/>
-  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 17.595h232.529v8.73H.132z"/>
-  <g font-weight="700" font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="23.621" y="223.83" transform="matrix(.99992 0 0 1.00008 0 -218.154)">
-      <tspan x="23.621" y="223.83" font-size="4.233">CBOR Feature</tspan>
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="352" viewBox="0 0 232.833 93.133" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
+  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.144.132h232.563V10.45H.144z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.144 31.088h232.563v10.318H.144z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.144 41.407h232.563v10.318H.144z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.144 51.726h232.567v10.318H.144z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.144 62.045h232.567v10.318H.144zM.143 82.682h232.569V93H.143z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.144 10.451h232.563V20.77H.144z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.144 20.77h232.568v10.318H.144z"/>
+  <g font-weight="700" font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="10.92" y="223.83" transform="matrix(.99992 0 0 1.00008 0 -217.361)">
+      <tspan x="10.92" y="223.83" font-size="4.233">CBOR Feature</tspan>
     </text>
-    <text y="223.83" x="133.147" style="line-height:23.99999946%" transform="matrix(.99992 0 0 1.00008 0 -218.154)">
-      <tspan y="223.83" x="133.147" font-size="4.233">Description</tspan>
-    </text>
-  </g>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 61.25h232.529v8.732H.132z"/>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".036" stroke-linejoin="round" d="M7.93.159h.227v78.669H7.93zM64.253.162h.227v78.6h-.227z"/>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="10.903" y="232.554" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -218.073)">
-      <tspan x="10.903" y="232.554" font-size="4.057" fill="#4d4d4d">CBOR tags</tspan>
-    </text>
-    <text y="232.554" x="67.538" style="line-height:23.99999946%" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -218.073)">
-      <tspan y="232.554" x="67.538" font-size="4.057">API supports built-in and user-defined tags.</tspan>
+    <text y="223.83" x="68.055" style="line-height:23.99999946%" transform="matrix(.99992 0 0 1.00008 0 -217.361)">
+      <tspan y="223.83" x="68.055" font-size="4.233">Description</tspan>
     </text>
   </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text y="241.812" x="10.808" style="line-height:23.99999946%" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -218.622)">
-      <tspan y="241.812" x="10.808" font-size="4.057" fill="#4d4d4d">Preferred serialization</tspan>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.144 72.363h232.567v10.318H.144z"/>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".039" stroke-linejoin="round" d="M7.955.256h.229v92.86h-.229zM64.312.223h.229V93.05h-.229z"/>
+  <g font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="10.948" y="221.36" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan x="10.948" y="221.36" font-size="4.057" fill="#4d4d4d">CBOR tags</tspan>
     </text>
-    <text style="line-height:23.99999946%" x="67.538" y="241.812" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -218.622)">
-      <tspan x="67.538" y="241.812" font-size="4.057">Integers encode to fewest bytes. Optional float64 <tspan fill="#00a000">→ </tspan>float32 <tspan fill="#00a000">→ </tspan>float16 if value fits.</tspan>
-    </text>
-  </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="10.808" y="250.064" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -218.143)">
-      <tspan x="10.808" y="250.064" font-size="4.057" fill="#4d4d4d">Map key sorting</tspan>
-    </text>
-    <text y="250.064" x="67.538" style="line-height:23.99999946%" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -218.143)">
-      <tspan y="250.064" x="67.538" font-size="4.057">Unsorted, length-first (Canonical CBOR), and bytewise-lexicographic (CTAP2).</tspan>
+    <text y="221.36" x="67.37" style="line-height:23.99999946%" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan y="221.36" x="67.37" font-size="4.057">API supports built-in and user-defined tags.</tspan>
     </text>
   </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text y="267.536" x="10.777" style="line-height:23.99999946%" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -218.154)">
-      <tspan y="267.536" x="10.777" font-size="4.057" fill="#4d4d4d">Indefinite length data</tspan>
+  <g font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text y="231.68" x="10.853" style="line-height:23.99999946%" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan y="231.68" x="10.853" font-size="4.057" fill="#4d4d4d">Preferred serialization</tspan>
     </text>
-    <text style="line-height:23.99999946%" x="67.538" y="267.536" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -218.154)">
-      <tspan x="67.538" y="267.536" font-size="4.057">Option to allow/forbid for encoding and decoding.</tspan>
-    </text>
-  </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="11.01" y="276.734" font-weight="600" fill="#4d4d4d" transform="matrix(.99992 0 0 1.00008 0 -218.622)">
-      <tspan x="11.01" y="276.734" font-size="4.057">Well-formedness checks</tspan>
-    </text>
-    <text y="276.734" x="67.538" style="line-height:23.99999946%" font-weight="400" fill="#333" transform="matrix(.99992 0 0 1.00008 0 -218.622)">
-      <tspan y="276.734" x="67.538" font-size="4.057">Always checked and enforced.</tspan>
+    <text style="line-height:23.99999946%" x="67.37" y="231.68" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan x="67.37" y="231.68" font-size="4.057">Integers encode to fewest bytes. Optional float64 <tspan fill="#00a000">→ </tspan>float32 <tspan fill="#00a000">→ </tspan>float16 if value fits.</tspan>
     </text>
   </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <text y="284.987" x="10.808" style="line-height:23.99999946%" font-weight="600" fill="#4d4d4d" transform="matrix(.99992 0 0 1.00008 0 -218.154)">
-      <tspan y="284.987" x="10.808" font-size="4.057">Basic validity checks</tspan>
+  <g font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="10.853" y="242.111" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan x="10.853" y="242.111" font-size="4.057" fill="#4d4d4d">Map key sorting</tspan>
     </text>
-    <text style="line-height:23.99999946%" x="67.538" y="284.987" font-weight="400" fill="#333" transform="matrix(.99992 0 0 1.00008 0 -218.154)">
-      <tspan x="67.538" y="284.987" font-size="4.057">UTF-8 validity and optional duplicate map keys.</tspan>
-    </text>
-  </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="10.96" y="293.453" font-weight="600" fill="#4d4d4d" transform="matrix(.99992 0 0 1.00008 0 -218.143)">
-      <tspan x="10.96" y="293.453" font-size="4.057">Security considerations</tspan>
-    </text>
-    <text y="293.453" x="67.538" style="line-height:23.99999946%" font-weight="400" fill="#333" transform="matrix(.99992 0 0 1.00008 0 -218.143)">
-      <tspan y="293.453" x="67.538" font-size="4.057">Prevent integer overflow and resource exhaustion (RFC 7049 Section 8).</tspan>
+    <text y="242.111" x="67.37" style="line-height:23.99999946%" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan y="242.111" x="67.37" font-size="4.057">Unsorted, length-first (Canonical CBOR), and bytewise-lexicographic (CTAP2).</tspan>
     </text>
   </g>
-  <g font-size="4.938" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="10.808" y="258.795" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -218.143)">
-      <tspan x="10.808" y="258.795" font-size="4.057" fill="#4d4d4d">Duplicate map keys</tspan>
+  <g font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text y="262.634" x="10.822" style="line-height:23.99999946%" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan y="262.634" x="10.822" font-size="4.057" fill="#4d4d4d">Indefinite length data</tspan>
     </text>
-    <text y="258.795" x="67.538" style="line-height:23.99999946%" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -218.143)">
-      <tspan y="258.795" x="67.538" font-size="4.057">Always forbid for encoding and option to allow/forbid for decoding.</tspan>
+    <text style="line-height:23.99999946%" x="67.37" y="262.634" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan x="67.37" y="262.634" font-size="4.057">Option to allow/forbid for encoding and decoding.</tspan>
     </text>
   </g>
-  <text y="292.638" x="71.779" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -218.154)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265"/>
-  <path d="M3.238 13.272q.108 0 .163.176.11.33.157.33.036 0 .075-.054.774-1.138 1.432-1.62.279-.205.543-.205.35 0 .422.022.03.008.03.07 0 .049-.063.123-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121zM3.238 21.982q.108 0 .163.176.11.33.157.33.036 0 .075-.054.774-1.139 1.432-1.62.279-.205.543-.205.35 0 .422.022.03.008.03.069 0 .05-.063.124-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121zM3.238 30.713q.108 0 .163.176.11.331.157.331.036 0 .075-.055.774-1.138 1.432-1.62.279-.205.543-.205.35 0 .422.022.03.008.03.07 0 .049-.063.123-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121zM3.238 39.444q.108 0 .163.177.11.33.157.33.036 0 .075-.055.774-1.138 1.432-1.62.279-.204.543-.204.35 0 .422.022.03.008.03.069 0 .05-.063.124-1.772 2.034-2.11 2.645-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.134.193-.223.265-.12.397-.12zM3.238 48.175q.108 0 .163.177.11.33.157.33.036 0 .075-.055.774-1.138 1.432-1.62.279-.204.543-.204.35 0 .422.022.03.008.03.069 0 .05-.063.124-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.073-.063-.033-.22-.421-.199-.49-.199-.86 0-.135.193-.223.265-.122.397-.122zM3.238 56.907q.108 0 .163.176.11.33.157.33.036 0 .075-.054.774-1.139 1.432-1.62.279-.205.543-.205.35 0 .422.022.03.008.03.07 0 .049-.063.123-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121zM3.238 65.638q.108 0 .163.176.11.331.157.331.036 0 .075-.055.774-1.138 1.432-1.62.279-.205.543-.205.35 0 .422.022.03.008.03.07 0 .049-.063.123-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121zM3.238 74.105q.108 0 .163.176.11.33.157.33.036 0 .075-.054.774-1.139 1.432-1.62.279-.205.543-.205.35 0 .422.022.03.008.03.069 0 .05-.063.124-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121z" font-size="5.644" fill="green" aria-label="✔" style="font-size:5.64444494px;fill:#008000;stroke-width:0.26458332" font-weight="400" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265"/>
+  <g font-size="4.938" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="11.055" y="272.976" font-weight="600" fill="#4d4d4d" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan x="11.055" y="272.976" font-size="4.057">Well-formedness checks</tspan>
+    </text>
+    <text y="272.976" x="67.37" style="line-height:23.99999946%" font-weight="400" fill="#333" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan y="272.976" x="67.37" font-size="4.057">Always checked and enforced.</tspan>
+    </text>
+  </g>
+  <g font-size="4.938" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <text y="283.293" x="10.853" style="line-height:23.99999946%" font-weight="600" fill="#4d4d4d" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan y="283.293" x="10.853" font-size="4.057">Basic validity checks</tspan>
+    </text>
+    <text style="line-height:23.99999946%" x="67.37" y="283.293" font-weight="400" fill="#333" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan x="67.37" y="283.293" font-size="4.057">Check UTF-8 validity and optionally check duplicate map keys.</tspan>
+    </text>
+  </g>
+  <g font-size="4.938" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="11.005" y="293.701" font-weight="600" fill="#4d4d4d" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan x="11.005" y="293.701" font-size="4.057">Security considerations</tspan>
+    </text>
+    <text y="293.701" x="67.37" style="line-height:23.99999946%" font-weight="400" fill="#333" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan y="293.701" x="67.37" font-size="4.057">Prevent integer overflow and resource exhaustion (RFC 7049 Section 8).</tspan>
+    </text>
+  </g>
+  <g font-size="4.938" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <text style="line-height:23.99999946%" x="10.853" y="252.316" font-weight="600" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan x="10.853" y="252.316" font-size="4.057" fill="#4d4d4d">Duplicate map keys</tspan>
+    </text>
+    <text y="252.316" x="67.37" style="line-height:23.99999946%" font-weight="400" transform="matrix(.99992 0 0 1.00008 0 -204.66)">
+      <tspan y="252.316" x="67.37" font-size="4.057">Always forbid for encoding and option to allow/forbid for decoding.</tspan>
+    </text>
+  </g>
+  <path d="M3.238 15.448q.108 0 .163.176.11.33.157.33.036 0 .075-.054.774-1.138 1.432-1.62.279-.205.543-.205.35 0 .422.022.03.008.03.07 0 .049-.063.123-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121zm0 10.319q.108 0 .163.176.11.33.157.33.036 0 .075-.054.774-1.139 1.432-1.621.279-.204.543-.204.35 0 .422.022.03.008.03.069 0 .05-.063.124-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.034-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121zm0 10.318q.108 0 .163.177.11.33.157.33.036 0 .075-.055.774-1.138 1.432-1.62.279-.204.543-.204.35 0 .422.022.03.008.03.069 0 .05-.063.124-1.772 2.034-2.11 2.646-.117.209-.536.209-.137 0-.289-.072-.063-.033-.22-.421-.199-.49-.199-.86 0-.135.193-.223.265-.122.397-.122zm0 10.319q.108 0 .163.176.11.331.157.331.036 0 .075-.055.774-1.138 1.432-1.62.279-.204.543-.204.35 0 .422.022.03.008.03.068 0 .05-.063.124-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121zm0 10.319q.108 0 .163.176.11.33.157.33.036 0 .075-.054.774-1.138 1.432-1.62.279-.205.543-.205.35 0 .422.022.03.008.03.07 0 .049-.063.123-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121zm0 10.319q.108 0 .163.176.11.33.157.33.036 0 .075-.054.774-1.139 1.432-1.621.279-.204.543-.204.35 0 .422.022.03.008.03.069 0 .05-.063.124-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.034-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.122.397-.122zm0 10.318q.108 0 .163.177.11.33.157.33.036 0 .075-.055.774-1.138 1.432-1.62.279-.204.543-.204.35 0 .422.022.03.008.03.069 0 .05-.063.124-1.772 2.034-2.11 2.646-.117.209-.536.209-.137 0-.289-.072-.063-.033-.22-.421-.199-.49-.199-.86 0-.135.193-.223.265-.122.397-.122zm0 10.319q.108 0 .163.176.11.331.157.331.036 0 .075-.055.774-1.138 1.432-1.62.279-.204.543-.204.35 0 .422.022.03.008.03.068 0 .05-.063.124-1.772 2.034-2.11 2.646-.117.21-.536.21-.137 0-.289-.072-.063-.033-.22-.422-.199-.49-.199-.86 0-.135.193-.223.265-.121.397-.121z" font-size="5.644" fill="green" aria-label="✔" font-weight="400" letter-spacing="0" word-spacing="0" stroke-width=".265"/>
 </svg>

--- a/cbor/v2.2.0/cbor_memory_table.svg
+++ b/cbor/v2.2.0/cbor_memory_table.svg
@@ -1,49 +1,43 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="880" height="117" viewBox="0 0 232.833 30.956">
-  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132-.133h232.569v10.32H.132z"/>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 10.186H232.7v10.32H.132z"/>
-  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 20.505H232.7v10.32H.132z"/>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M135.676-.179h.243v30.933h-.243z"/>
-  <g font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="71.088" y="272.476" transform="matrix(1 0 0 1 0 -266.335)">
-      <tspan x="71.088" y="272.476" font-size="4.233" fill="#333">fxamacker/cbor 2.2</tspan>
-    </text>
-    <text y="272.476" x="165.309" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -266.335)">
-      <tspan y="272.476" x="165.309" font-size="4.233" fill="#333">ugorji/go 1.1.7</tspan>
-    </text>
-  </g>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M51.01-.179h.243v30.933h-.243z"/>
-  <g font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="99.277" y="282.789" font-weight="400" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan x="99.277" y="282.789" font-size="4.149">2 allocs/op</tspan>
-    </text>
-    <text y="282.789" x="2.784" style="line-height:23.99999946%" font-weight="600" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan y="282.789" x="2.784" font-size="4.145">Encode CWT Claims</tspan>
-    </text>
-    <text y="282.789" x="64.881" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan y="282.789" x="64.881" font-size="4.149">176 B/op</tspan>
-    </text>
-    <text y="282.789" x="186.588" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan y="282.789" x="186.588" font-size="4.149">4 allocs/op</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="153.78" y="282.789" font-weight="400" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan x="153.78" y="282.789" font-size="4.149">1424 B/op</tspan>
-    </text>
-  </g>
-  <g font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="2.784" y="293.107" font-weight="600" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan x="2.784" y="293.107" font-size="4.145">Decode CWT Claims</tspan>
-    </text>
-    <text y="293.107" x="99.277" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan y="293.107" x="99.277" font-size="4.149">6 allocs/op</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="64.881" y="293.107" font-weight="400" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan x="64.881" y="293.107" font-size="4.149">176 B/op</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="186.588" y="293.107" font-weight="400" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan x="186.588" y="293.107" font-size="4.149">6 allocs/op</tspan>
-    </text>
-    <text y="293.107" x="155.897" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.363)">
-      <tspan y="293.107" x="155.897" font-size="4.149">568 B/op</tspan>
-    </text>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="117" viewBox="0 0 211.667 30.956" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
+  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.126-.139h211.402v10.323H.126z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.126 10.184h211.402v10.323H.126z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.126 20.507h211.402V30.83H.126z"/>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M129.657-.179h.242v30.933h-.242z"/>
+  <text y="272.184" x="61.575" style="line-height:23.99999946%" transform="translate(0 -266.044)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan y="272.184" x="61.575" font-size="4.233" fill="#333">fxamacker/cbor 2.2</tspan>
+  </text>
+  <text style="line-height:23.99999946%" x="135.739" y="272.184" transform="translate(0 -266.044)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan x="135.739" y="272.184" font-size="4.233" fill="#333">ugorji/go 1.1.7</tspan>
+  </text>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M55.309-.179h.242v30.933h-.242z"/>
+  <text y="282.548" x="116.16" style="line-height:23.99999946%;text-align:end" transform="translate(0 -266.044)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="282.548" x="116.16" font-size="4.149">2 allocs/op</tspan>
+  </text>
+  <text transform="translate(0 -266.044)" style="line-height:23.99999946%" x="2.784" y="282.548" font-weight="600" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="2.784" y="282.548" font-size="4.145">Encode CWT Claims</tspan>
+  </text>
+  <text transform="translate(0 -266.044)" style="line-height:23.99999946%;text-align:end" x="78.09" y="282.548" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="78.09" y="282.548" style="text-align:end" font-size="4.149">176 B/op</tspan>
+  </text>
+  <text transform="translate(0 -266.044)" style="line-height:23.99999946%;text-align:end" x="190.732" y="282.548" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="190.732" y="282.548" style="text-align:end" font-size="4.149">4 allocs/op</tspan>
+  </text>
+  <text y="282.548" x="155.33" style="line-height:23.99999946%;text-align:end" transform="translate(0 -266.044)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="282.548" x="155.33" font-size="4.149">1424 B/op</tspan>
+  </text>
+  <text transform="translate(0 -266.044)" y="292.867" x="2.784" style="line-height:23.99999946%" font-weight="600" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="292.867" x="2.784" font-size="4.145">Decode CWT Claims</tspan>
+  </text>
+  <text transform="translate(0 -266.044)" style="line-height:23.99999946%;text-align:end" x="116.28" y="292.867" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="116.28" y="292.867" style="text-align:end" font-size="4.149">6 allocs/op</tspan>
+  </text>
+  <text y="292.867" x="78.09" style="line-height:23.99999946%;text-align:end" transform="translate(0 -266.044)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="292.867" x="78.09" font-size="4.149">176 B/op</tspan>
+  </text>
+  <text y="292.867" x="190.627" style="line-height:23.99999946%;text-align:end" transform="translate(0 -266.044)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="292.867" x="190.627" font-size="4.149">6 allocs/op</tspan>
+  </text>
+  <text transform="translate(0 -266.044)" style="line-height:23.99999946%;text-align:end" x="155.34" y="292.867" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="155.34" y="292.867" style="text-align:end" font-size="4.149">568 B/op</tspan>
+  </text>
 </svg>

--- a/cbor/v2.2.0/cbor_security_table.svg
+++ b/cbor/v2.2.0/cbor_security_table.svg
@@ -1,65 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="880" height="118" viewBox="0 0 232.833 31.221">
-  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132.198h232.569v10.319H.132z"/>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 10.484H232.7v10.319H.132z"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="118" viewBox="0 0 232.833 31.221" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
+  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132.132h232.569V10.45H.132z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 10.45H232.7v10.32H.132z"/>
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 20.77H232.7v10.319H.132z"/>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M128.797.086h.243v30.933h-.243z"/>
-  <text y="272.25" x="63.15" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -265.78)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <tspan y="272.25" x="63.15" font-size="4.233" fill="#333">fxamacker/cbor 2.2</tspan>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M131.509.086h.242v30.933h-.242z"/>
+  <text y="272.25" x="54.167" style="line-height:23.99999946%" transform="translate(0 -265.78)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan y="272.25" x="54.167" font-size="4.233" fill="#333">fxamacker/cbor 2.2</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="161.605" y="272.25" transform="matrix(1 0 0 1 0 -265.78)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <tspan x="161.605" y="272.25" font-size="4.233" fill="#333">ugorji/go 1.1.7</tspan>
+  <text style="line-height:23.99999946%" x="136.004" y="272.25" transform="translate(0 -265.78)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan x="136.004" y="272.25" font-size="4.233" fill="#333">ugorji/go 1.1.7</tspan>
   </text>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M47.835.086h.243v30.933h-.243z"/>
-  <g font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="100.335" y="282.99" font-weight="400" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan x="100.335" y="282.99" font-size="4.149">1 allocs/op</tspan>
-    </text>
-    <text y="282.99" x="139.492" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan y="282.99" x="139.492" font-weight="700" font-size="4.145" fill="maroon">fatal error:<tspan font-weight="600"> out of memory</tspan></tspan>
-    </text>
-    <text y="282.99" x="2.784" style="line-height:23.99999946%" font-weight="600" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan y="282.99" x="2.784" font-size="4.145">Malformed Data #1</tspan>
-    </text>
-    <text y="282.99" x="51.123" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan y="282.99" x="51.123" font-size="4.149">60.6 ns/op</tspan>
-    </text>
-    <text y="282.99" x="78.11" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan y="282.99" x="78.11" font-size="4.149">40 B/op</tspan>
-    </text>
-  </g>
-  <g font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="139.492" y="293.276" font-weight="400" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan x="139.492" y="293.276" font-weight="700" font-size="4.145" fill="maroon">runtime: <tspan font-weight="600">out of memory: cannot allocate</tspan></tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="2.784" y="293.276" font-weight="600" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan x="2.784" y="293.276" font-size="4.145">Malformed Data #2</tspan>
-    </text>
-    <text y="293.276" x="100.335" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan y="293.276" x="100.335" font-size="4.149">1 allocs/op</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="51.123" y="293.276" font-weight="400" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan x="51.123" y="293.276" font-size="4.149">61.7 ns/op</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="78.11" y="293.276" font-weight="400" transform="matrix(1 0 0 1 0 -266.257)">
-      <tspan x="78.11" y="293.276" font-size="4.149">40 B/op</tspan>
-    </text>
-  </g>
-  <path style="solid-color:#000" d="M134.662 12.994l-.014.002a.304.304 0 00-.261.15l-1.048 1.816-1.048 1.815a.308.308 0 00.263.457h4.193c.23 0 .378-.258.263-.457l-1.048-1.815-1.048-1.816a.304.304 0 00-.234-.149.067.067 0 00-.018-.003z" color="#000"/>
-  <path d="M134.662 13.061a.237.237 0 00-.217.119l-1.048 1.815-1.048 1.816a.24.24 0 00.205.355h4.193c.18 0 .295-.2.205-.355l-1.048-1.816-1.048-1.815a.237.237 0 00-.194-.119z" style="solid-color:#000" color="#000" fill="#fff"/>
-  <path d="M134.659 13.128a.17.17 0 00-.156.085l-1.048 1.816-1.048 1.815a.17.17 0 00.147.255h4.193a.17.17 0 00.147-.255l-1.048-1.815-1.048-1.816a.17.17 0 00-.14-.085z" style="solid-color:#000" color="#000"/>
-  <path d="M136.747 16.93h-4.193l1.048-1.816 1.049-1.816 1.048 1.816z" fill="#fc0"/>
-  <g transform="matrix(.03354 0 0 .03354 132.016 12.752)">
-    <circle cx="78.564" cy="111.117" r="8.817"/>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M47.901.086h.242v30.933h-.242z"/>
+  <text y="282.547" x="126.207" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="282.547" x="126.207" font-size="4.149">1 allocs/op</tspan>
+  </text>
+  <text style="line-height:23.99999946%" x="143.725" y="282.547" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="143.725" y="282.547" font-weight="700" font-size="4.145" fill="maroon">fatal error:<tspan font-weight="600"> out of memory</tspan></tspan>
+  </text>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%" x="4.465" y="282.547" font-weight="600" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="4.465" y="282.547" font-size="4.145">Malformed Data #1</tspan>
+  </text>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="74.92" y="282.547" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="74.92" y="282.547" style="text-align:end" font-size="4.149">60.6 ns/op</tspan>
+  </text>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="98.23" y="282.547" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="98.23" y="282.547" style="text-align:end" font-size="4.149">40 B/op</tspan>
+  </text>
+  <text y="292.88" x="143.725" style="line-height:23.99999946%" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="292.88" x="143.725" font-weight="700" font-size="4.145" fill="maroon">runtime:<tspan font-weight="600"> out of memory: cannot allocate</tspan></tspan>
+  </text>
+  <text transform="translate(0 -265.78)" y="292.88" x="4.465" style="line-height:23.99999946%" font-weight="600" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="292.88" x="4.465" font-size="4.145">Malformed Data #2</tspan>
+  </text>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="126.207" y="292.88" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="126.207" y="292.88" style="text-align:end" font-size="4.149">1 allocs/op</tspan>
+  </text>
+  <text y="292.88" x="74.92" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="292.88" x="74.92" font-size="4.149">61.7 ns/op</tspan>
+  </text>
+  <text y="292.88" x="98.23" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="292.88" x="98.23" font-size="4.149">40 B/op</tspan>
+  </text>
+  <path d="M138.67 12.994l-.013.002a.304.304 0 00-.26.15l-1.049 1.816-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.049-1.816-1.048-1.815a.304.304 0 00-.234-.15l-.015-.002a.06.06 0 00-.003 0z" style="solid-color:#000" color="#000" stroke-width=".034"/>
+  <path style="solid-color:#000" d="M138.67 13.061a.238.238 0 00-.216.119l-1.048 1.815-1.048 1.816a.24.24 0 00.205.355h4.193c.18 0 .295-.2.205-.355l-1.048-1.816-1.048-1.815a.237.237 0 00-.194-.119z" color="#000" fill="#fff" stroke-width=".034"/>
+  <path style="solid-color:#000" d="M138.668 13.128a.17.17 0 00-.156.085l-1.048 1.816-1.048 1.815a.17.17 0 00.147.255h4.193a.17.17 0 00.147-.255l-1.048-1.815-1.048-1.816a.17.17 0 00-.14-.085z" color="#000" stroke-width=".034"/>
+  <path d="M140.756 16.93h-4.192l1.048-1.816 1.048-1.816 1.048 1.816z" fill="#fc0" stroke-width=".034"/>
+  <g transform="translate(136.025 12.752) scale(.03354)">
+    <circle r="8.817" cy="111.117" cx="78.564"/>
     <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>
   </g>
-  <g>
-    <path d="M134.662 23.28l-.014.002a.304.304 0 00-.261.15l-1.048 1.816-1.048 1.815a.308.308 0 00.263.457h4.193c.23 0 .378-.258.263-.457l-1.048-1.815-1.048-1.816a.304.304 0 00-.234-.149.067.067 0 00-.018-.003z" style="solid-color:#000" color="#000"/>
-    <path style="solid-color:#000" d="M134.662 23.347a.237.237 0 00-.217.119l-1.048 1.815-1.048 1.816a.24.24 0 00.205.355h4.193c.18 0 .295-.2.205-.355l-1.048-1.816-1.048-1.815a.237.237 0 00-.194-.119z" color="#000" fill="#fff"/>
-    <path style="solid-color:#000" d="M134.659 23.414a.17.17 0 00-.156.085l-1.048 1.816-1.048 1.815a.17.17 0 00.147.255h4.193a.17.17 0 00.147-.255l-1.048-1.815-1.048-1.816a.17.17 0 00-.14-.085z" color="#000"/>
-    <path d="M136.747 27.215h-4.193l1.048-1.815 1.049-1.816 1.048 1.816z" fill="#fc0"/>
-    <g transform="matrix(.03354 0 0 .03354 132.016 23.038)">
-      <circle r="8.817" cy="111.117" cx="78.564"/>
-      <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>
-    </g>
+  <path style="solid-color:#000" d="M138.67 23.28l-.013.002a.304.304 0 00-.26.15l-1.049 1.816-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.049-1.816-1.048-1.815a.304.304 0 00-.234-.15l-.015-.002a.06.06 0 00-.003 0z" color="#000" stroke-width=".034"/>
+  <path d="M138.67 23.347a.238.238 0 00-.216.119l-1.048 1.815-1.048 1.816a.24.24 0 00.205.355h4.193c.18 0 .295-.2.205-.355l-1.048-1.816-1.048-1.815a.237.237 0 00-.194-.119z" style="solid-color:#000" color="#000" fill="#fff" stroke-width=".034"/>
+  <path d="M138.668 23.414a.17.17 0 00-.156.085l-1.048 1.816-1.048 1.815a.17.17 0 00.147.255h4.193a.17.17 0 00.147-.255l-1.048-1.815-1.048-1.816a.17.17 0 00-.14-.085z" style="solid-color:#000" color="#000" stroke-width=".034"/>
+  <path d="M140.756 27.215h-4.192l1.048-1.815 1.048-1.816 1.048 1.816z" fill="#fc0" stroke-width=".034"/>
+  <g transform="translate(136.025 23.038) scale(.03354)">
+    <circle cx="78.564" cy="111.117" r="8.817"/>
+    <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>
   </g>
 </svg>

--- a/cbor/v2.2.0/cbor_speed_comparison_barchart.svg
+++ b/cbor/v2.2.0/cbor_speed_comparison_barchart.svg
@@ -1,54 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="746" height="250" viewBox="0 0 197.379 66.146">
+<svg xmlns="http://www.w3.org/2000/svg" width="746" height="250" viewBox="0 0 197.379 66.146" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
   <path fill="#fff" stroke="#fff" stroke-width=".426" d="M.213.213h196.953v65.719H.213z"/>
   <path fill="#999" stroke-width=".085" stroke-linejoin="round" d="M119.484 42.855h.265V46.1h-.265z"/>
-  <text y="242.935" x=".066" style="line-height:23.99999946%" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.635" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
-    <tspan y="242.935" x=".066" font-size="3.874" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#666">Using Go structs with example data from RFC 8392 Appendix A.1</tspan>
+  <text y="242.935" x=".066" style="line-height:23.99999946%" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
+    <tspan y="242.935" x=".066" font-size="3.874" fill="#666">Using Go structs with example data from RFC 8392 Appendix A.1</tspan>
   </text>
-  <text y="237.607" x=".066" style="line-height:23.99999946%" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.635" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
-    <tspan style="-inkscape-font-specification:'Inter Medium'" y="237.607" x=".066" font-weight="500" font-size="4.227" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#333">CBOR Speed Comparison</tspan>
+  <text y="237.607" x=".066" style="line-height:23.99999946%" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
+    <tspan style="-inkscape-font-specification:'Inter Medium'" y="237.607" x=".066" font-weight="500" font-size="4.227" fill="#333">CBOR Speed Comparison</tspan>
   </text>
-  <text y="291.384" x=".066" style="line-height:23.99999946%" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.635" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
-    <tspan y="291.384" x=".066" font-size="3.874" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#666">codec.CborHandle (ugorji/go) is created outside the benchmark loop.</tspan>
+  <text y="291.914" x=".066" style="line-height:23.99999946%" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
+    <tspan y="291.914" x=".066" font-size="3.874" fill="#666">codec.CborHandle (ugorji/go) is created outside the benchmark loop.</tspan>
   </text>
   <path fill="#4285f4" stroke="#fff" stroke-width=".339" d="M-62.498-360.094h3.894v3.894h-3.894z" transform="matrix(1 0 0 .99678 204.22 378.167)"/>
-  <text y="-356.793" x="-56.591" style="line-height:23.99999946%" font-weight="400" font-size="5.644" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 204.22 378.167)">
-    <tspan y="-356.793" x="-56.591" font-weight="700" font-size="4.24" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#4080ff">fxamacker/cbor 2.2</tspan>
+  <text y="-356.793" x="-56.591" style="line-height:23.99999946%" font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 204.22 378.167)">
+    <tspan y="-356.793" x="-56.591" font-weight="600" font-size="4.24" fill="#4080ff">fxamacker/cbor 2.2</tspan>
   </text>
   <path fill="#db4437" stroke="#fff" stroke-width=".339" d="M-62.272-349.472h3.894v3.894h-3.894z" transform="matrix(1 0 0 .99678 203.994 386.754)"/>
-  <text y="-346.168" x="-56.489" style="line-height:23.99999946%" font-weight="400" font-size="5.644" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 203.994 386.754)">
-    <tspan y="-346.168" x="-56.489" font-weight="700" font-size="4.24" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#c04020">ugorji/go 1.1.7</tspan>
+  <text y="-346.168" x="-56.489" style="line-height:23.99999946%" font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 203.994 386.754)">
+    <tspan y="-346.168" x="-56.489" font-weight="600" font-size="4.24" fill="#c04020">ugorji/go 1.1.7</tspan>
   </text>
-  <text style="line-height:1em" x="147.087" y="259.087" transform="matrix(1.00162 0 0 .99839 -.025 -230.854)" font-weight="400" font-size="5.635" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
+  <text style="line-height:1em" x="147.087" y="259.087" transform="matrix(1.00162 0 0 .99839 -.025 -230.854)" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
     <tspan x="147.087" y="259.087" style="line-height:50%" font-size="3.528" fill="#666">not using Go&apos;s unsafe pkg</tspan>
   </text>
-  <text style="line-height:1em" x="147.056" y="263.771" transform="matrix(1.00162 0 0 .99839 -.025 -230.854)" font-weight="400" font-size="5.635" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
-    <tspan x="147.056" y="263.771" style="line-height:50%;-inkscape-font-specification:'Open Sans'" font-size="3.528" font-family="Open Sans" fill="#666">not using code gen</tspan>
+  <text style="line-height:1em" x="147.056" y="263.857" transform="matrix(1.00162 0 0 .99839 -.025 -230.854)" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
+    <tspan x="147.056" y="263.857" style="line-height:50%" font-size="3.528" fill="#666">not using code gen</tspan>
   </text>
-  <text style="line-height:1em" x="147.087" y="278.432" transform="matrix(1.00162 0 0 .99839 -.025 -230.854)" font-weight="400" font-size="5.635" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
+  <text style="line-height:1em" x="147.087" y="278.432" transform="matrix(1.00162 0 0 .99839 -.025 -230.854)" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
     <tspan x="147.087" y="278.432" style="line-height:50%" font-size="3.528" fill="#666">using Go&apos;s unsafe pkg</tspan>
   </text>
-  <text style="line-height:1em" x="147.087" y="283.203" transform="matrix(1.00162 0 0 .99839 -.025 -230.854)" font-weight="400" font-size="5.635" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".264">
+  <text style="line-height:1em" x="147.087" y="283.203" transform="matrix(1.00162 0 0 .99839 -.025 -230.854)" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
     <tspan x="147.087" y="283.203" style="line-height:50%" font-size="3.528" fill="#666">using code gen</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="141.313" y="242.543" font-weight="400" font-size="4.939" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(-.025 -230.854)">
+  <text style="line-height:23.99999946%" x="141.313" y="242.543" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(-.025 -230.854)">
     <tspan x="141.313" y="242.543" font-size="3.881">Using default build options</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="72.659" y="282.506" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.864" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".275">
-    <tspan x="72.659" y="282.506" font-size="3.522" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#757575">500 ns/op</tspan>
+  <text style="line-height:23.99999946%" x="72.659" y="282.506" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.864" letter-spacing="0" word-spacing="0" stroke-width=".275">
+    <tspan x="72.659" y="282.506" font-size="3.522" fill="#757575">500 ns/op</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="112.602" y="282.506" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.864" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".275">
-    <tspan x="112.602" y="282.506" font-size="3.522" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#757575">1K ns/op</tspan>
+  <text style="line-height:23.99999946%" x="112.602" y="282.506" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.864" letter-spacing="0" word-spacing="0" stroke-width=".275">
+    <tspan x="112.602" y="282.506" font-size="3.522" fill="#757575">1K ns/op</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="82.141" y="253.058" font-weight="400" font-size="3.881" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -230.854)">
+  <text style="line-height:23.99999946%" x="82.141" y="253.058" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -230.854)">
     <tspan x="82.141" y="253.058" font-size="3.528" fill="gray">← Faster</tspan>
   </text>
-  <text transform="matrix(1.00162 0 0 .99839 0 -230.854)" y="282.506" x="41.756" style="line-height:23.99999946%" font-weight="400" font-size="5.864" font-family="sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".275">
-    <tspan y="282.506" x="41.756" font-size="3.522" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" fill="#757575">0</tspan>
+  <text transform="matrix(1.00162 0 0 .99839 0 -230.854)" y="282.506" x="41.756" style="line-height:23.99999946%" font-weight="400" font-size="5.864" letter-spacing="0" word-spacing="0" stroke-width=".275">
+    <tspan y="282.506" x="41.756" font-size="3.522" fill="#757575">0</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="40.939" y="270.021" font-weight="400" font-size="4.939" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(0 -230.854)">
+  <text style="line-height:23.99999946%" x="40.939" y="270.021" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(0 -230.854)">
     <tspan x="40.939" y="270.021" style="text-align:end" font-size="3.528" text-anchor="end" fill="#4d4d4d">Decode CWT Claims</tspan>
   </text>
-  <text y="255.533" x="40.944" style="line-height:23.99999946%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Inter,Public Sans,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(0 -230.854)">
+  <text y="255.533" x="40.944" style="line-height:23.99999946%" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#666" stroke-width=".265" transform="translate(0 -230.854)">
     <tspan style="text-align:end" y="255.533" x="40.944" font-size="3.528" text-anchor="end" fill="#4d4d4d">Encode CWT Claims</tspan>
   </text>
   <path fill="#4285f4" stroke="#e0e0e0" stroke-width=".347" stroke-linejoin="round" d="M43.285 18.765h34.338v4.914H43.285z"/>

--- a/cbor/v2.2.0/cbor_speed_table.svg
+++ b/cbor/v2.2.0/cbor_speed_table.svg
@@ -1,57 +1,55 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="880" height="118" viewBox="0 0 232.833 31.221">
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="118" viewBox="0 0 232.833 31.221" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
   <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132.132h232.569V10.45H.132z"/>
   <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 10.45H232.7v10.32H.132z"/>
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 20.77H232.7v10.319H.132z"/>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M135.676.243h.243v30.933h-.243z"/>
-  <text y="282.946" x="107.214" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -265.78)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="282.946" x="107.214" font-size="4.149">2 allocs/op</tspan>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M137.066.243h.242v30.933h-.242z"/>
+  <text y="272.408" x="57.342" style="line-height:23.99999946%" transform="translate(0 -265.78)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan y="272.408" x="57.342" font-size="4.233" fill="#333">fxamacker/cbor 2.2</tspan>
   </text>
-  <text y="272.408" x="70.558" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -265.78)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <tspan y="272.408" x="70.558" font-size="4.233" fill="#333">fxamacker/cbor 2.2</tspan>
+  <text style="line-height:23.99999946%" x="144.206" y="272.408" transform="translate(0 -265.78)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan x="144.206" y="272.408" font-size="4.233" fill="#333">ugorji/go 1.1.7</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="165.839" y="272.408" transform="matrix(1 0 0 1 0 -265.78)" font-weight="700" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <tspan x="165.839" y="272.408" font-size="4.233" fill="#333">ugorji/go 1.1.7</tspan>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M51.076.243h.242v30.933h-.242z"/>
+  <text y="282.548" x="131.426" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="282.548" x="131.426" font-size="4.149">2 allocs/op</tspan>
   </text>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M51.01.243h.243v30.933h-.243z"/>
-  <text transform="matrix(1 0 0 1 0 -265.78)" style="line-height:23.99999946%" x="2.784" y="282.946" font-weight="600" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="2.784" y="282.946" font-size="4.145">Encode CWT Claims</tspan>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%" x="2.784" y="282.548" font-weight="600" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="2.784" y="282.548" font-size="4.145">Encode CWT Claims</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -265.78)" style="line-height:23.99999946%" x="54.417" y="282.946" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="54.417" y="282.946" font-size="4.149">451 ns/op</tspan>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="76.642" y="282.548" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="76.642" y="282.548" style="text-align:end" font-size="4.149">451 ns/op</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -265.78)" style="line-height:23.99999946%" x="81.814" y="282.946" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="81.814" y="282.946" font-size="4.149">176 B/op</tspan>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="101.824" y="282.548" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="101.824" y="282.548" style="text-align:end" font-size="4.149">176 B/op</tspan>
   </text>
-  <text transform="matrix(1 0 0 1 0 -265.78)" style="line-height:23.99999946%" x="199.817" y="282.946" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="199.817" y="282.946" font-size="4.149">4 allocs/op</tspan>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="225.175" y="282.548" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="225.175" y="282.548" style="text-align:end" font-size="4.149">4 allocs/op</tspan>
   </text>
-  <text y="282.946" x="142.668" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -265.78)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="282.946" x="142.668" font-size="4.149">977 ns/op</tspan>
+  <text y="282.548" x="165.719" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="282.548" x="165.719" font-size="4.149">977 ns/op</tspan>
   </text>
-  <text y="282.946" x="170.714" style="line-height:23.99999946%" transform="matrix(1 0 0 1 0 -265.78)" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="282.946" x="170.714" font-size="4.149">1424 B/op</tspan>
+  <text y="282.548" x="194.536" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="282.548" x="194.536" font-size="4.149">1424 B/op</tspan>
   </text>
-  <g font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <text style="line-height:23.99999946%" x="2.784" y="293.107" font-weight="600" transform="matrix(1 0 0 1 0 -266.098)">
-      <tspan x="2.784" y="293.107" font-size="4.145">Decode CWT Claims</tspan>
-    </text>
-    <text y="293.107" x="107.214" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.098)">
-      <tspan y="293.107" x="107.214" font-size="4.149">6 allocs/op</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="54.313" y="293.107" font-weight="400" transform="matrix(1 0 0 1 0 -266.098)">
-      <tspan x="54.313" y="293.107" font-size="4.149">765 ns/op</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="81.814" y="293.107" font-weight="400" transform="matrix(1 0 0 1 0 -266.098)">
-      <tspan x="81.814" y="293.107" font-size="4.149">176 B/op</tspan>
-    </text>
-    <text style="line-height:23.99999946%" x="199.817" y="293.107" font-weight="400" transform="matrix(1 0 0 1 0 -266.098)">
-      <tspan x="199.817" y="293.107" font-size="4.149">6 allocs/op</tspan>
-    </text>
-    <text y="293.107" x="140.022" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.098)">
-      <tspan y="293.107" x="140.022" font-size="4.149">1100 ns/op</tspan>
-    </text>
-    <text y="293.107" x="172.83" style="line-height:23.99999946%" font-weight="400" transform="matrix(1 0 0 1 0 -266.098)">
-      <tspan y="293.107" x="172.83" font-size="4.149">568 B/op</tspan>
-    </text>
-  </g>
+  <text transform="translate(0 -265.78)" y="292.867" x="2.784" style="line-height:23.99999946%" font-weight="600" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="292.867" x="2.784" font-size="4.145">Decode CWT Claims</tspan>
+  </text>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="131.546" y="292.867" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="131.546" y="292.867" style="text-align:end" font-size="4.149">6 allocs/op</tspan>
+  </text>
+  <text y="292.867" x="76.871" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="292.867" x="76.871" font-size="4.149">765 ns/op</tspan>
+  </text>
+  <text y="292.867" x="101.824" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="292.867" x="101.824" font-size="4.149">176 B/op</tspan>
+  </text>
+  <text y="292.867" x="225.07" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="292.867" x="225.07" font-size="4.149">6 allocs/op</tspan>
+  </text>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="165.719" y="292.867" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="165.719" y="292.867" style="text-align:end" font-size="4.149">1100 ns/op</tspan>
+  </text>
+  <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="194.546" y="292.867" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="194.546" y="292.867" style="text-align:end" font-size="4.149">568 B/op</tspan>
+  </text>
 </svg>

--- a/cbor/v2.2.0/cbor_struct_tags_api.svg
+++ b/cbor/v2.2.0/cbor_struct_tags_api.svg
@@ -9,102 +9,105 @@
     <marker orient="auto" refY="0" refX="0" id="a" overflow="visible">
       <path d="M10 0l4-4L0 0l14 4-4-4z" fill-rule="evenodd" stroke="green" stroke-width=".8pt" fill="green"/>
     </marker>
+    <style>
+      .sans{font-family:&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif}.mono{font-family:&quot;SF Mono&quot;,SFMono-Regular,Consolas,&quot;Liberation Mono&quot;,&quot;Source Code Pro&quot;,&quot;DejaVu Sans Mono&quot;,&quot;Roboto Mono&quot;,Menlo,monospace}
+    </style>
   </defs>
-  <text style="line-height:125%" y="216.093" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="0" y="216.093" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace" fill="green">// Example: CBOR Web Token (RFC 8392)</tspan>
+  <text style="line-height:125%" y="216.093" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="0" y="216.093" style="line-height:100%" font-size="3.881" class="mono" fill="green">// Example: CBOR Web Token (RFC 8392)</tspan>
   </text>
-  <text y="221.384" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="221.384" x="0" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace"><tspan fill="#00f">type</tspan> <tspan fill="#333">coseHeader</tspan> <tspan fill="#00f">struct</tspan> {</tspan>
+  <text y="221.384" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="221.384" x="0" font-size="3.881" class="mono"><tspan fill="#00f">type</tspan> <tspan fill="#333">coseHeader</tspan> <tspan fill="#00f">struct</tspan> {</tspan>
   </text>
-  <text style="line-height:125%" x="32.279" y="226.676" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="32.279" y="226.676" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace"><tspan fill="maroon">`cbor:&quot;1,keyasint,omitempty&quot;`</tspan></tspan>
+  <text style="line-height:125%" x="32.279" y="226.676" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="32.279" y="226.676" style="line-height:100%" font-size="3.881" class="mono"><tspan fill="maroon">`cbor:&quot;1,keyasint,omitempty&quot;`</tspan></tspan>
   </text>
-  <text y="231.968" x="32.279" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="231.968" x="32.279" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace"><tspan fill="maroon">`cbor:&quot;4,keyasint,omitempty&quot;`</tspan></tspan>
+  <text y="231.968" x="32.279" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="231.968" x="32.279" font-size="3.881" class="mono"><tspan fill="maroon">`cbor:&quot;4,keyasint,omitempty&quot;`</tspan></tspan>
   </text>
-  <text style="line-height:125%" y="237.259" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="0" y="237.259" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace">}</tspan>
+  <text style="line-height:125%" y="237.259" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="0" y="237.259" style="line-height:100%" font-size="3.881" class="mono">}</tspan>
   </text>
-  <text y="245.197" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="245.197" x="0" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace"><tspan fill="#00f">type</tspan> <tspan fill="#333">signedCWT</tspan> <tspan fill="#00f">struct</tspan> {</tspan>
+  <text y="245.197" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="245.197" x="0" font-size="3.881" class="mono"><tspan fill="#00f">type</tspan> <tspan fill="#333">signedCWT</tspan> <tspan fill="#00f">struct</tspan> {</tspan>
   </text>
-  <text style="line-height:125%" x="34.925" y="250.488" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="34.925" y="250.488" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace"><tspan fill="#00f">struct</tspan>{} <tspan fill="maroon">`cbor:&quot;,toarray&quot;`</tspan></tspan>
+  <text style="line-height:125%" x="34.925" y="250.488" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="34.925" y="250.488" style="line-height:100%" font-size="3.881" class="mono"><tspan fill="#00f">struct</tspan>{} <tspan fill="maroon">`cbor:&quot;,toarray&quot;`</tspan></tspan>
   </text>
-  <text y="255.78" x="34.925" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="255.78" x="34.925" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace">[]<tspan fill="#00f">byte</tspan></tspan>
+  <text y="255.78" x="34.925" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="255.78" x="34.925" font-size="3.881" class="mono">[]<tspan fill="#00f">byte</tspan></tspan>
   </text>
-  <text style="line-height:125%" x="6.879" y="261.071" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="6.879" y="261.071" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace" fill="#333">Unprotected coseHeader</tspan>
+  <text style="line-height:125%" x="6.879" y="261.071" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="6.879" y="261.071" style="line-height:100%" font-size="3.881" class="mono" fill="#333">Unprotected coseHeader</tspan>
   </text>
-  <text y="266.363" x="34.925" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="266.363" x="34.925" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace">[]<tspan fill="#00f">byte</tspan></tspan>
+  <text y="266.363" x="34.925" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="266.363" x="34.925" font-size="3.881" class="mono">[]<tspan fill="#00f">byte</tspan></tspan>
   </text>
-  <text style="line-height:125%" y="276.946" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="0" y="276.946" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace">}</tspan>
+  <text style="line-height:125%" y="276.946" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="0" y="276.946" style="line-height:100%" font-size="3.881" class="mono">}</tspan>
   </text>
-  <text y="285.413" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="285.413" x="0" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace" fill="green">// Decode []byte into signedCWT struct</tspan>
+  <text y="285.413" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="285.413" x="0" font-size="3.881" class="mono" fill="green">// Decode []byte into signedCWT struct</tspan>
   </text>
-  <text style="line-height:125%" y="290.704" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="0" y="290.704" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace" fill="#333"><tspan fill="#00f">var</tspan> v signedCWT</tspan>
+  <text style="line-height:125%" y="290.704" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="0" y="290.704" style="line-height:100%" font-size="3.881" class="mono" fill="#333"><tspan fill="#00f">var</tspan> v signedCWT</tspan>
   </text>
-  <text style="line-height:125%" y="295.996" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="0" y="295.996" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace" fill="#333">err := cbor.Unmarshal(t, &amp;v)</tspan>
+  <text style="line-height:125%" y="295.996" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="0" y="295.996" style="line-height:100%" font-size="3.881" class="mono" fill="#333">err := cbor.Unmarshal(t, &amp;v)</tspan>
   </text>
-  <text y="235.393" x="117.283" style="line-height:23.99999946%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan y="235.393" x="117.283" font-size="4.233">elements of CBOR map with int keys.</tspan>
+  <text y="235.393" x="118.87" style="line-height:23.99999946%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan y="235.393" x="118.87" font-size="4.233" class="sans">elements of CBOR map with int keys.</tspan>
   </text>
-  <text y="250.834" x="117.451" style="line-height:23.99999946%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan y="250.834" x="117.451"><tspan font-weight="700">toarray</tspan><tspan> </tspan><tspan font-size="4.233">translates struct fields to</tspan></tspan>
+  <text y="250.834" x="119.038" style="line-height:23.99999946%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan y="250.834" x="119.038"><tspan font-weight="700" class="sans">toarray</tspan><tspan class="sans"> </tspan><tspan font-size="4.233" class="sans">translates struct fields to</tspan></tspan>
   </text>
-  <text style="line-height:23.99999946%" x="117.283" y="257.618" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="117.283" y="257.618" font-size="4.233">elements of CBOR arrays.</tspan>
+  <text style="line-height:23.99999946%" x="118.87" y="257.618" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="118.87" y="257.618" font-size="4.233" class="sans">elements of CBOR arrays.</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="117.456" y="289.368" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="117.456" y="289.368"><tspan font-weight="700">API</tspan><tspan> </tspan><tspan font-size="4.233">uses same function signatures</tspan></tspan>
+  <text style="line-height:23.99999946%" x="119.043" y="289.368" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="119.043" y="289.368"><tspan font-weight="700" class="sans">API</tspan><tspan class="sans"> </tspan><tspan font-size="4.233" class="sans">uses same function signatures</tspan></tspan>
   </text>
-  <text y="295.983" x="117.223" style="line-height:23.99999946%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan y="295.983" x="117.223" font-size="4.233">as Go&apos;s json/encoding package.</tspan>
+  <text y="295.983" x="118.81" style="line-height:23.99999946%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan y="295.983" x="118.81" font-size="4.233" class="sans">as Go&apos;s json/encoding package.</tspan>
   </text>
-  <text style="line-height:125%" x="34.925" y="271.655" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="34.925" y="271.655" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace">[]<tspan fill="#00f">byte</tspan></tspan>
+  <text style="line-height:125%" x="34.925" y="271.655" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="34.925" y="271.655" style="line-height:100%" font-size="3.881" class="mono">[]<tspan fill="#00f">byte</tspan></tspan>
   </text>
-  <text y="216.093" x="117.349" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="216.093" x="117.349" font-size="4.233" fill="green">fxamacker/cbor struct tags and API</tspan>
+  <text y="216.093" x="118.936" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="216.093" x="118.936" font-size="4.233" class="sans" fill="green">fxamacker/cbor struct tags and API</tspan>
   </text>
-  <text y="228.609" x="117.205" style="line-height:23.99999946%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan y="228.609" x="117.205"><tspan font-weight="700">keyasint</tspan><tspan font-size="4.233"> translates struct fields to</tspan></tspan>
+  <text y="228.609" x="118.792" style="line-height:23.99999946%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan y="228.609" x="118.792"><tspan font-weight="700" class="sans">keyasint</tspan><tspan font-size="4.233" class="sans"> translates struct fields to</tspan></tspan>
   </text>
-  <text y="226.676" x="6.879" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="226.676" x="6.879" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace"><tspan fill="#333">Alg</tspan> <tspan fill="#00f">int</tspan></tspan>
+  <text y="226.676" x="6.879" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="226.676" x="6.879" font-size="3.881" class="mono"><tspan fill="#333">Alg</tspan> <tspan fill="#00f">int</tspan></tspan>
   </text>
-  <text style="line-height:125%" x="6.879" y="231.968" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="6.879" y="231.968" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace"><tspan fill="#333">Kid</tspan> []<tspan fill="#00f">byte</tspan></tspan>
+  <text style="line-height:125%" x="6.879" y="231.968" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="6.879" y="231.968" style="line-height:100%" font-size="3.881" class="mono"><tspan fill="#333">Kid</tspan> []<tspan fill="#00f">byte</tspan></tspan>
   </text>
-  <text y="250.488" x="6.879" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="250.488" x="6.879" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace">_</tspan>
+  <text y="250.488" x="6.879" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="250.488" x="6.879" font-size="3.881" class="mono">_</tspan>
   </text>
-  <text style="line-height:125%" x="6.879" y="255.78" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="6.879" y="255.78" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace"><tspan fill="#333">Protected</tspan></tspan>
+  <text style="line-height:125%" x="6.879" y="255.78" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="6.879" y="255.78" style="line-height:100%" font-size="3.881" class="mono"><tspan fill="#333">Protected</tspan></tspan>
   </text>
-  <text style="line-height:125%" x="6.879" y="266.363" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="6.879" y="266.363" style="line-height:100%" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace">Payload</tspan>
+  <text style="line-height:125%" x="6.879" y="266.363" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="6.879" y="266.363" style="line-height:100%" font-size="3.881" class="mono">Payload</tspan>
   </text>
-  <text y="271.655" x="6.879" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="271.655" x="6.879" font-size="3.881" font-family="'SF Mono',Menlo,Monaco,Consolas,'Roboto Mono','Source Code Pro','Liberation Mono','DejaVu Sans Mono',monospace"><tspan fill="#333">Signature</tspan></tspan>
+  <text y="271.655" x="6.879" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="271.655" x="6.879" font-size="3.881" class="mono"><tspan fill="#333">Signature</tspan></tspan>
   </text>
-  <path d="M88.257 188.143h-9.071" transform="matrix(-.64243 0 0 1 163.927 -173.553)" fill="green" stroke="green" stroke-width=".33" marker-start="url(#a)"/>
-  <path transform="matrix(-.64243 0 0 1 163.927 -151.213)" d="M88.257 188.143h-9.071" fill="green" stroke="green" stroke-width=".33" marker-start="url(#b)"/>
-  <path d="M88.257 188.143h-9.071" transform="matrix(-.64243 0 0 1 163.927 -112.825)" fill="green" stroke="green" stroke-width=".33" marker-start="url(#c)"/>
-  <text style="line-height:125%" x="117.173" y="269.525" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan x="117.173" y="269.525" style="line-height:100%" font-size="4.233">Enable options (if required) like</tspan>
+  <path d="M88.257 188.143h-9.071" transform="matrix(-.64243 0 0 1 165.515 -173.553)" fill="green" stroke="green" stroke-width=".33" marker-start="url(#a)"/>
+  <path transform="matrix(-.64243 0 0 1 165.515 -151.213)" d="M88.257 188.143h-9.071" fill="green" stroke="green" stroke-width=".33" marker-start="url(#b)"/>
+  <path d="M88.257 188.143h-9.071" transform="matrix(-.64243 0 0 1 165.515 -112.825)" fill="green" stroke="green" stroke-width=".33" marker-start="url(#c)"/>
+  <text style="line-height:125%" x="118.76" y="269.525" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan x="118.76" y="269.525" style="line-height:100%" font-size="4.233" class="sans">Enable options (if required) like</tspan>
   </text>
-  <text y="276.139" x="117.173" style="line-height:125%" font-weight="400" font-size="4.939" font-family="SF Pro Text,Helvetica Neue,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arial,sans-serif" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
-    <tspan style="line-height:100%" y="276.139" x="117.173" font-size="4.233">detecting duplicate map keys.</tspan>
+  <text y="276.139" x="118.76" style="line-height:125%" font-weight="400" font-size="4.939" class="sans" letter-spacing="0" word-spacing="0" fill="#4d4d4d" stroke-width=".265" transform="translate(0 -212.333)">
+    <tspan style="line-height:100%" y="276.139" x="118.76" font-size="4.233" class="sans">detecting duplicate map keys.</tspan>
   </text>
   <g fill="green">
-    <path d="M109.556 55.173a2.019 2.019 0 012.018 2.018 2.467 2.467 0 01-.403 1.329c-.09.165-.186.347-.291.565a2.624 2.624 0 00-.154.404c0 .036-.024.085-.036.12h-2.249c0-.035-.028-.084-.036-.12a2.624 2.624 0 00-.154-.404 11.67 11.67 0 00-.29-.565 2.467 2.467 0 01-.424-1.329 2.019 2.019 0 012.019-2.018m0-.404a2.423 2.423 0 00-2.423 2.422c0 .808.31 1.16.759 2.072.174.35.15.755.452.755h2.423c.303 0 .278-.404.456-.755.444-.913.755-1.264.755-2.072a2.423 2.423 0 00-2.422-2.422zM108.796 62.037a.828.828 0 00.76.403.828.828 0 00.759-.403z"/>
-    <path d="M108.344 60.018v.238l1.837.165a.202.202 0 01-.02.404h-.02l-1.797-.165v.403l1.837.166a.202.202 0 01-.02.404h-.02l-1.797-.166v.166a.404.404 0 00.404.404h1.615a.404.404 0 00.404-.404v-1.615z"/>
+    <path d="M111.143 55.173a2.019 2.019 0 012.019 2.018 2.467 2.467 0 01-.404 1.329c-.089.165-.186.347-.29.565a2.624 2.624 0 00-.154.404c0 .036-.024.085-.036.12h-2.25c0-.035-.028-.084-.036-.12a2.624 2.624 0 00-.153-.404 11.67 11.67 0 00-.29-.565 2.467 2.467 0 01-.425-1.329 2.019 2.019 0 012.019-2.018m0-.404a2.423 2.423 0 00-2.423 2.422c0 .808.311 1.16.76 2.072.173.35.149.755.452.755h2.422c.303 0 .279-.404.457-.755.444-.913.755-1.264.755-2.072a2.423 2.423 0 00-2.423-2.422zm-.759 7.268a.828.828 0 00.759.403.828.828 0 00.76-.403z"/>
+    <path d="M109.932 60.018v.238l1.837.165a.202.202 0 01-.02.404h-.02l-1.797-.165v.403l1.837.166a.202.202 0 01-.02.404h-.02l-1.797-.166v.166a.404.404 0 00.403.404h1.616a.404.404 0 00.403-.404v-1.615z"/>
   </g>
 </svg>


### PR DESCRIPTION
Reduce file sizes by not repeating long font-family strings.  The long font-family is to help avoid fonts wider than SF Pro Text because the column size is fixed.

The numbers in the speed comparison table can be updated without vector editor. The price for this convenience is the ns/op number isn't perfectly aligned to the left (they're aligned to the right and will vary to the left when numbers are updated or when user fonts change).

@fxamacker do not merge yet.