### PR TITLE
Create cbor_security_638px.svg

### DIFF
--- a/cbor/v2.2.0/cbor_security_638px.svg
+++ b/cbor/v2.2.0/cbor_security_638px.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="638" height="153" viewBox="0 0 168.804 40.481" font-family="Roboto,Arial,Liberation Sans,Arimo,Oxygen,Cantarell,sans-serif">
+  <path fill="#fffffc" stroke-width=".252" stroke-linejoin="round" d="M0 2.116h168.804v38.365H0z"/>
+  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".264" stroke-linejoin="round" d="M.113 2.25h168.54v10.318H.113z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".264" stroke-linejoin="round" d="M.113 12.567h168.54v10.32H.113z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".264" stroke-linejoin="round" d="M.113 22.886h168.539v10.32H.113z"/>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M80.709 2.467h.242V33.4h-.242z"/>
+  <text y="265.371" x="19.242" style="line-height:23.99999946%" transform="translate(0 -256.519)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan y="265.371" x="19.242" font-size="4.233" fill="#333">fxamacker/cbor 2.2</tspan>
+  </text>
+  <text style="line-height:23.99999946%" x="83.617" y="265.371" transform="translate(0 -256.519)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan x="83.617" y="265.371" font-size="4.233" fill="#333">ugorji/go 1.1.7</tspan>
+  </text>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M16.151 2.466h.242V33.4h-.242z"/>
+  <text y="275.668" x="76.995" style="line-height:23.99999946%;text-align:end" transform="translate(0 -256.519)" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="275.668" x="76.995">1 allocs/op</tspan>
+  </text>
+  <text style="line-height:23.99999946%" x="91.338" y="275.668" transform="translate(0 -256.519)" font-weight="700" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="91.338" y="275.668" fill="maroon">fatal error: out of memory</tspan>
+  </text>
+  <text transform="translate(0 -256.519)" style="line-height:23.99999946%" x="2.338" y="275.668" font-weight="600" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="2.338" y="275.668" font-weight="700">Test 1</tspan>
+  </text>
+  <text transform="translate(0 -256.519)" style="line-height:23.99999946%;text-align:end" x="37.349" y="275.668" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="37.349" y="275.668" style="text-align:end">60.6 ns/op</tspan>
+  </text>
+  <text transform="translate(0 -256.519)" style="line-height:23.99999946%;text-align:end" x="54.31" y="275.668" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="54.31" y="275.668" style="text-align:end">40 B/op</tspan>
+  </text>
+  <text y="286.001" x="91.338" style="line-height:23.99999946%" transform="translate(0 -256.519)" font-weight="700" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="286.001" x="91.338" fill="maroon">runtime: out of memory: cannot allocate</tspan>
+  </text>
+  <text transform="translate(0 -256.519)" y="286.001" x="2.338" style="line-height:23.99999946%" font-weight="600" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="286.001" x="2.338" font-weight="700">Test 2</tspan>
+  </text>
+  <text transform="translate(0 -256.519)" style="line-height:23.99999946%;text-align:end" x="76.995" y="286.001" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="76.995" y="286.001" style="text-align:end">1 allocs/op</tspan>
+  </text>
+  <text y="286.001" x="37.349" style="line-height:23.99999946%;text-align:end" transform="translate(0 -256.519)" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="286.001" x="37.349">61.7 ns/op</tspan>
+  </text>
+  <text y="286.001" x="54.31" style="line-height:23.99999946%;text-align:end" transform="translate(0 -256.519)" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="286.001" x="54.31">40 B/op</tspan>
+  </text>
+  <path d="M86.283 15.376c-.005 0-.009 0-.013.002a.303.303 0 00-.262.15l-1.048 1.815-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.048-1.816-1.048-1.815a.304.304 0 00-.235-.15l-.014-.002a.06.06 0 00-.004 0z" style="solid-color:#000" color="#000" stroke-width=".034"/>
+  <path style="solid-color:#000" d="M86.283 15.443a.238.238 0 00-.216.118l-1.049 1.816-1.048 1.815a.24.24 0 00.206.356h4.192c.18 0 .295-.2.206-.356l-1.048-1.815-1.049-1.816a.237.237 0 00-.194-.118z" color="#000" fill="#fff" stroke-width=".034"/>
+  <path style="solid-color:#000" d="M86.28 15.51a.17.17 0 00-.155.085l-1.048 1.815-1.049 1.815a.17.17 0 00.148.256h4.192a.17.17 0 00.148-.256l-1.049-1.815-1.048-1.815a.17.17 0 00-.139-.085z" color="#000" stroke-width=".034"/>
+  <path d="M88.368 19.31h-4.192l1.048-1.815 1.048-1.815 1.048 1.815z" fill="#fc0" stroke-width=".034"/>
+  <g transform="translate(83.637 15.133) scale(.03354)">
+    <circle r="8.817" cy="111.117" cx="78.564"/>
+    <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>
+  </g>
+  <path style="solid-color:#000" d="M86.283 25.662c-.005 0-.009 0-.013.002a.303.303 0 00-.262.15L84.96 27.63l-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.048-1.816-1.048-1.815a.304.304 0 00-.235-.15l-.014-.002a.06.06 0 00-.004 0z" color="#000" stroke-width=".034"/>
+  <path d="M86.283 25.729a.238.238 0 00-.216.118l-1.049 1.816-1.048 1.815a.24.24 0 00.206.356h4.192c.18 0 .295-.2.206-.356l-1.048-1.815-1.049-1.816a.237.237 0 00-.194-.118z" style="solid-color:#000" color="#000" fill="#fff" stroke-width=".034"/>
+  <path d="M86.28 25.796a.17.17 0 00-.155.085l-1.048 1.815-1.049 1.816a.17.17 0 00.148.255h4.192a.17.17 0 00.148-.255l-1.049-1.816-1.048-1.815a.17.17 0 00-.139-.085z" style="solid-color:#000" color="#000" stroke-width=".034"/>
+  <path d="M88.368 29.597h-4.192l1.048-1.816 1.048-1.815 1.048 1.815z" fill="#fc0" stroke-width=".034"/>
+  <g transform="translate(83.637 25.42) scale(.03354)">
+    <circle cx="78.564" cy="111.117" r="8.817"/>
+    <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>
+  </g>
+  <text style="line-height:100%" x="8.928" y="296.195" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -256.519)">
+    <tspan x="8.928" y="296.195" font-size="3.881" fill="#4d4d4d">Malformed data were shorter than this sentence. Decoding tests used default options.</tspan>
+  </text>
+  <path d="M6.083 38.631v-1.99l-.482.481-.248-.248.813-.812h.186l.812.812-.248.248-.482-.481v1.639h1.15v.351z" aria-label="↴" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" fill="green" stroke-width=".265"/>
+</svg>


### PR DESCRIPTION
CBOR security comparison table.  Decoding malicious CBOR data shorter than this sentence can lead to resource exhaustion when using another library.

Wider fonts like SF Pro Text and DejaVu Sans cannot be used given the fixed width:  
font-family="Roboto,Arial,Liberation Sans,Arimo,Oxygen,Cantarell,sans-serif"