### PR TITLE
Update several cbor comparison tables

### DIFF
--- a/cbor/v2.2.0/cbor_app_size_barchart.svg
+++ b/cbor/v2.2.0/cbor_app_size_barchart.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="746" height="250" viewBox="0 0 197.379 66.146" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="746" height="250" viewBox="0 0 197.379 66.146" font-family="SF Pro Text,Inter,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
   <path fill="#fff" stroke="#fff" stroke-width=".426" d="M.213.213h196.953v65.719H.213z"/>
-  <path fill="#999" stroke-width=".085" stroke-linejoin="round" d="M114.545 42.856h.265V46.1h-.265z"/>
+  <path fill="#999" d="M114.545 42.856h.265V46.1h-.265z"/>
   <g font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265">
     <text style="line-height:23.99999946%" x="39.632" y="235.645" transform="matrix(1 0 0 .99678 -39.588 -223.197)">
       <tspan x="39.632" y="235.645" font-size="3.881" fill="#666">Same apps can be 4-9 MB smaller by using fxamacker/cbor</tspan>
@@ -20,11 +20,11 @@
   </text>
   <path fill="#4285f4" stroke="#fff" stroke-width=".339" d="M-62.498-360.094h3.894v3.894h-3.894z" transform="matrix(1 0 0 .99678 203.955 378.167)"/>
   <text style="line-height:23.99999946%" x="-56.591" y="-356.793" font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 203.955 378.167)">
-    <tspan x="-56.591" y="-356.793" font-weight="600" font-size="4.24" fill="#4080ff">fxamacker/cbor 2.2</tspan>
+    <tspan x="-56.591" y="-356.793" font-weight="600" font-size="4.24" fill="#2060e0">fxamacker/cbor 2.2</tspan>
   </text>
   <path fill="#db4437" stroke="#fff" stroke-width=".339" d="M-62.272-349.472h3.894v3.894h-3.894z" transform="matrix(1 0 0 .99678 203.73 386.754)"/>
   <text style="line-height:23.99999946%" x="-56.489" y="-346.168" font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 203.73 386.754)">
-    <tspan x="-56.489" y="-346.168" font-weight="600" font-size="4.24" fill="#c04020">ugorji/go 1.1.7</tspan>
+    <tspan x="-56.489" y="-346.168" font-weight="600" font-size="4.24" fill="#a02000">ugorji/go 1.1.7</tspan>
   </text>
   <text transform="matrix(1.00162 0 0 .99839 -.29 -230.854)" y="259.087" x="147.087" style="line-height:1em" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
     <tspan style="line-height:50%" y="259.087" x="147.087" font-size="3.528" fill="#666">not using Go&apos;s unsafe pkg</tspan>
@@ -54,10 +54,10 @@
     <tspan style="text-align:end" y="255.533" x="40.922" font-size="3.528" text-anchor="end" fill="#4d4d4d">custom app (private)</tspan>
   </text>
   <path fill="#4285f4" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M43.008 18.765h19.94v4.915h-19.94z"/>
-  <path fill="#999" stroke-width=".085" stroke-linejoin="round" d="M78.562 42.86h.265v3.24h-.265z"/>
+  <path fill="#999" d="M78.562 42.86h.265v3.24h-.265z"/>
   <path fill="#4285f4" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M42.975 33.214h54.556v4.754H42.975z"/>
   <path fill="#db4436" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M43.008 38.042h86.146v4.688H43.008zm-.001-14.289h85.472v4.69H43.007z"/>
-  <path fill="#999" stroke-width=".248" stroke-linejoin="round" d="M42.578 18.633h.265V46.1h-.265z"/>
+  <path fill="#999" d="M42.578 18.633h.265V46.1h-.265z"/>
   <text y="267.345" x="99.581" style="line-height:23.99999946%" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -230.854)">
     <tspan y="267.345" x="99.581" font-size="3.528" fill="gray">← 4.4 MB smaller</tspan>
   </text>

--- a/cbor/v2.2.0/cbor_security_638px.svg
+++ b/cbor/v2.2.0/cbor_security_638px.svg
@@ -1,64 +1,64 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="638" height="153" viewBox="0 0 168.804 40.481" font-family="Roboto,Arial,Liberation Sans,Arimo,Oxygen,Cantarell,sans-serif">
-  <path fill="#fffffc" stroke-width=".252" stroke-linejoin="round" d="M0 2.116h168.804v38.365H0z"/>
-  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".264" stroke-linejoin="round" d="M.113 2.25h168.54v10.318H.113z"/>
-  <path fill="#fff" stroke="#e0e0e0" stroke-width=".264" stroke-linejoin="round" d="M.113 12.567h168.54v10.32H.113z"/>
-  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".264" stroke-linejoin="round" d="M.113 22.886h168.539v10.32H.113z"/>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M80.709 2.467h.242V33.4h-.242z"/>
-  <text y="265.371" x="19.242" style="line-height:23.99999946%" transform="translate(0 -256.519)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <tspan y="265.371" x="19.242" font-size="4.233" fill="#333">fxamacker/cbor 2.2</tspan>
+  <path fill="#fffffc" d="M.02 2.116h168.804v38.365H.02z"/>
+  <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".264" stroke-linejoin="round" d="M.132 2.25h168.54v10.318H.132z"/>
+  <path fill="#fff" stroke="#e0e0e0" stroke-width=".264" stroke-linejoin="round" d="M.132 12.567h168.54v10.32H.132z"/>
+  <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".264" stroke-linejoin="round" d="M.132 22.886h168.539v10.32H.132z"/>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M80.729 2.467h.242V33.4h-.242z"/>
+  <text y="265.371" x="19.262" style="line-height:23.99999946%" transform="translate(0 -256.519)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan y="265.371" x="19.262" font-size="4.233" fill="#333">fxamacker/cbor 2.2</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="83.617" y="265.371" transform="translate(0 -256.519)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
-    <tspan x="83.617" y="265.371" font-size="4.233" fill="#333">ugorji/go 1.1.7</tspan>
+  <text style="line-height:23.99999946%" x="83.636" y="265.371" transform="translate(0 -256.519)" font-weight="700" font-size="4.939" letter-spacing="0" word-spacing="0" stroke-width=".265">
+    <tspan x="83.636" y="265.371" font-size="4.233" fill="#333">ugorji/go 1.1.7</tspan>
   </text>
-  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M16.151 2.466h.242V33.4h-.242z"/>
-  <text y="275.668" x="76.995" style="line-height:23.99999946%;text-align:end" transform="translate(0 -256.519)" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
-    <tspan style="text-align:end" y="275.668" x="76.995">1 allocs/op</tspan>
+  <path fill="#e0e0e0" stroke="#e0e0e0" stroke-width=".023" stroke-linejoin="round" d="M16.171 2.466h.242V33.4h-.242z"/>
+  <text y="275.668" x="77.014" style="line-height:23.99999946%;text-align:end" transform="translate(0 -256.519)" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="275.668" x="77.014">1 allocs/op</tspan>
   </text>
-  <text style="line-height:23.99999946%" x="91.338" y="275.668" transform="translate(0 -256.519)" font-weight="700" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="91.338" y="275.668" fill="maroon">fatal error: out of memory</tspan>
+  <text style="line-height:23.99999946%" x="91.358" y="275.668" transform="translate(0 -256.519)" font-weight="700" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="91.358" y="275.668" fill="maroon">fatal error: out of memory</tspan>
   </text>
-  <text transform="translate(0 -256.519)" style="line-height:23.99999946%" x="2.338" y="275.668" font-weight="600" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="2.338" y="275.668" font-weight="700">Test 1</tspan>
+  <text transform="translate(0 -256.519)" style="line-height:23.99999946%" x="2.357" y="275.668" font-weight="600" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan x="2.357" y="275.668" font-weight="700">Test 1</tspan>
   </text>
-  <text transform="translate(0 -256.519)" style="line-height:23.99999946%;text-align:end" x="37.349" y="275.668" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
-    <tspan x="37.349" y="275.668" style="text-align:end">60.6 ns/op</tspan>
+  <text transform="translate(0 -256.519)" style="line-height:23.99999946%;text-align:end" x="37.369" y="275.668" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="37.369" y="275.668" style="text-align:end">60.6 ns/op</tspan>
   </text>
-  <text transform="translate(0 -256.519)" style="line-height:23.99999946%;text-align:end" x="54.31" y="275.668" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
-    <tspan x="54.31" y="275.668" style="text-align:end">40 B/op</tspan>
+  <text transform="translate(0 -256.519)" style="line-height:23.99999946%;text-align:end" x="54.329" y="275.668" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="54.329" y="275.668" style="text-align:end">40 B/op</tspan>
   </text>
-  <text y="286.001" x="91.338" style="line-height:23.99999946%" transform="translate(0 -256.519)" font-weight="700" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="286.001" x="91.338" fill="maroon">runtime: out of memory: cannot allocate</tspan>
+  <text y="286.001" x="91.358" style="line-height:23.99999946%" transform="translate(0 -256.519)" font-weight="700" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="286.001" x="91.358" fill="maroon">runtime: out of memory: cannot allocate</tspan>
   </text>
-  <text transform="translate(0 -256.519)" y="286.001" x="2.338" style="line-height:23.99999946%" font-weight="600" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="286.001" x="2.338" font-weight="700">Test 2</tspan>
+  <text transform="translate(0 -256.519)" y="286.001" x="2.357" style="line-height:23.99999946%" font-weight="600" font-size="3.881" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
+    <tspan y="286.001" x="2.357" font-weight="700">Test 2</tspan>
   </text>
-  <text transform="translate(0 -256.519)" style="line-height:23.99999946%;text-align:end" x="76.995" y="286.001" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
-    <tspan x="76.995" y="286.001" style="text-align:end">1 allocs/op</tspan>
+  <text transform="translate(0 -256.519)" style="line-height:23.99999946%;text-align:end" x="77.014" y="286.001" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan x="77.014" y="286.001" style="text-align:end">1 allocs/op</tspan>
   </text>
-  <text y="286.001" x="37.349" style="line-height:23.99999946%;text-align:end" transform="translate(0 -256.519)" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
-    <tspan style="text-align:end" y="286.001" x="37.349">61.7 ns/op</tspan>
+  <text y="286.001" x="37.369" style="line-height:23.99999946%;text-align:end" transform="translate(0 -256.519)" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="286.001" x="37.369">61.7 ns/op</tspan>
   </text>
-  <text y="286.001" x="54.31" style="line-height:23.99999946%;text-align:end" transform="translate(0 -256.519)" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
-    <tspan style="text-align:end" y="286.001" x="54.31">40 B/op</tspan>
+  <text y="286.001" x="54.329" style="line-height:23.99999946%;text-align:end" transform="translate(0 -256.519)" font-weight="400" font-size="3.881" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
+    <tspan style="text-align:end" y="286.001" x="54.329">40 B/op</tspan>
   </text>
-  <path d="M86.283 15.376c-.005 0-.009 0-.013.002a.303.303 0 00-.262.15l-1.048 1.815-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.048-1.816-1.048-1.815a.304.304 0 00-.235-.15l-.014-.002a.06.06 0 00-.004 0z" style="solid-color:#000" color="#000" stroke-width=".034"/>
-  <path style="solid-color:#000" d="M86.283 15.443a.238.238 0 00-.216.118l-1.049 1.816-1.048 1.815a.24.24 0 00.206.356h4.192c.18 0 .295-.2.206-.356l-1.048-1.815-1.049-1.816a.237.237 0 00-.194-.118z" color="#000" fill="#fff" stroke-width=".034"/>
-  <path style="solid-color:#000" d="M86.28 15.51a.17.17 0 00-.155.085l-1.048 1.815-1.049 1.815a.17.17 0 00.148.256h4.192a.17.17 0 00.148-.256l-1.049-1.815-1.048-1.815a.17.17 0 00-.139-.085z" color="#000" stroke-width=".034"/>
-  <path d="M88.368 19.31h-4.192l1.048-1.815 1.048-1.815 1.048 1.815z" fill="#fc0" stroke-width=".034"/>
-  <g transform="translate(83.637 15.133) scale(.03354)">
+  <path d="M86.303 15.376c-.005 0-.01 0-.014.002a.303.303 0 00-.261.15l-1.048 1.815-1.048 1.816a.308.308 0 00.263.456h4.193c.23 0 .378-.258.263-.456l-1.048-1.816-1.048-1.815a.304.304 0 00-.234-.15l-.015-.002a.06.06 0 00-.003 0z" style="solid-color:#000" color="#000"/>
+  <path style="solid-color:#000" d="M86.303 15.443a.238.238 0 00-.217.118l-1.048 1.816-1.048 1.815a.24.24 0 00.205.356h4.193c.18 0 .295-.2.205-.356l-1.048-1.815-1.048-1.816a.237.237 0 00-.194-.118z" color="#000" fill="#fff"/>
+  <path style="solid-color:#000" d="M86.3 15.51a.17.17 0 00-.156.085l-1.048 1.815-1.048 1.815a.17.17 0 00.147.256h4.193a.17.17 0 00.147-.256l-1.048-1.815-1.048-1.815a.17.17 0 00-.14-.085z" color="#000"/>
+  <path d="M88.388 19.31h-4.193l1.048-1.815 1.049-1.815 1.048 1.815z" fill="#fc0"/>
+  <g transform="translate(83.657 15.133) scale(.03354)">
     <circle r="8.817" cy="111.117" cx="78.564"/>
     <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>
   </g>
-  <path style="solid-color:#000" d="M86.283 25.662c-.005 0-.009 0-.013.002a.303.303 0 00-.262.15L84.96 27.63l-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.048-1.816-1.048-1.815a.304.304 0 00-.235-.15l-.014-.002a.06.06 0 00-.004 0z" color="#000" stroke-width=".034"/>
-  <path d="M86.283 25.729a.238.238 0 00-.216.118l-1.049 1.816-1.048 1.815a.24.24 0 00.206.356h4.192c.18 0 .295-.2.206-.356l-1.048-1.815-1.049-1.816a.237.237 0 00-.194-.118z" style="solid-color:#000" color="#000" fill="#fff" stroke-width=".034"/>
-  <path d="M86.28 25.796a.17.17 0 00-.155.085l-1.048 1.815-1.049 1.816a.17.17 0 00.148.255h4.192a.17.17 0 00.148-.255l-1.049-1.816-1.048-1.815a.17.17 0 00-.139-.085z" style="solid-color:#000" color="#000" stroke-width=".034"/>
-  <path d="M88.368 29.597h-4.192l1.048-1.816 1.048-1.815 1.048 1.815z" fill="#fc0" stroke-width=".034"/>
-  <g transform="translate(83.637 25.42) scale(.03354)">
+  <path style="solid-color:#000" d="M86.303 25.662c-.005 0-.01 0-.014.002a.303.303 0 00-.261.15L84.98 27.63l-1.048 1.816a.308.308 0 00.263.456h4.193c.23 0 .378-.258.263-.456l-1.048-1.816-1.048-1.815a.304.304 0 00-.234-.15l-.015-.002a.06.06 0 00-.003 0z" color="#000"/>
+  <path d="M86.303 25.729a.238.238 0 00-.217.118l-1.048 1.816-1.048 1.815a.24.24 0 00.205.356h4.193c.18 0 .295-.2.205-.356l-1.048-1.815-1.048-1.816a.237.237 0 00-.194-.118z" style="solid-color:#000" color="#000" fill="#fff"/>
+  <path d="M86.3 25.796a.17.17 0 00-.156.085l-1.048 1.815-1.048 1.816a.17.17 0 00.147.255h4.193a.17.17 0 00.147-.255l-1.048-1.816-1.048-1.815a.17.17 0 00-.14-.085z" style="solid-color:#000" color="#000"/>
+  <path d="M88.388 29.597h-4.193l1.048-1.816 1.049-1.815 1.048 1.815z" fill="#fc0"/>
+  <g transform="translate(83.657 25.42) scale(.03354)">
     <circle cx="78.564" cy="111.117" r="8.817"/>
     <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>
   </g>
-  <text style="line-height:100%" x="8.928" y="296.195" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -256.519)">
-    <tspan x="8.928" y="296.195" font-size="3.881" fill="#4d4d4d">Malformed data were shorter than this sentence. Decoding tests used default options.</tspan>
+  <path d="M6.102 38.631v-1.99l-.481.481-.248-.248.812-.812h.186l.813.812-.249.248-.481-.481v1.639h1.15v.351z" aria-label="↴" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" fill="green"/>
+  <text y="296.195" x="8.947" style="line-height:100%" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -256.519)">
+    <tspan y="296.195" x="8.947" font-size="3.881" fill="#4d4d4d">Decoding tests used <tspan style="-inkscape-font-specification:'Liberation Sans Bold'" font-weight="700">9 bytes</tspan> (test 1) and <tspan style="-inkscape-font-specification:'Liberation Sans Bold'" font-weight="700">10 bytes</tspan> (test 2) of malformed CBOR data.</tspan>
   </text>
-  <path d="M6.083 38.631v-1.99l-.482.481-.248-.248.813-.812h.186l.812.812-.248.248-.482-.481v1.639h1.15v.351z" aria-label="↴" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" fill="green" stroke-width=".265"/>
 </svg>

--- a/cbor/v2.2.0/cbor_security_table.svg
+++ b/cbor/v2.2.0/cbor_security_table.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="880" height="118" viewBox="0 0 232.833 31.221" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="118" viewBox="0 0 232.833 31.221" font-family="SF Pro Text,Inter,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
   <path fill="#eef2ff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132.132h232.569V10.45H.132z"/>
   <path fill="#fff" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 10.45H232.7v10.32H.132z"/>
   <path fill="#f6f8fa" stroke="#e0e0e0" stroke-width=".265" stroke-linejoin="round" d="M.132 20.77H232.7v10.319H.132z"/>
@@ -17,7 +17,7 @@
     <tspan x="143.725" y="282.547" font-weight="700" font-size="4.145" fill="maroon">fatal error:<tspan font-weight="600"> out of memory</tspan></tspan>
   </text>
   <text transform="translate(0 -265.78)" style="line-height:23.99999946%" x="4.465" y="282.547" font-weight="600" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan x="4.465" y="282.547" font-size="4.145">Malformed Data #1</tspan>
+    <tspan x="4.465" y="282.547" font-size="4.145">Test (bad 9 bytes)</tspan>
   </text>
   <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="74.92" y="282.547" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
     <tspan x="74.92" y="282.547" style="text-align:end" font-size="4.149">60.6 ns/op</tspan>
@@ -29,7 +29,7 @@
     <tspan y="292.88" x="143.725" font-weight="700" font-size="4.145" fill="maroon">runtime:<tspan font-weight="600"> out of memory: cannot allocate</tspan></tspan>
   </text>
   <text transform="translate(0 -265.78)" y="292.88" x="4.465" style="line-height:23.99999946%" font-weight="600" font-size="4.939" letter-spacing="0" word-spacing="0" fill="#333" stroke-width=".265">
-    <tspan y="292.88" x="4.465" font-size="4.145">Malformed Data #2</tspan>
+    <tspan y="292.88" x="4.465" font-size="4.145">Test (bad 10 bytes)</tspan>
   </text>
   <text transform="translate(0 -265.78)" style="line-height:23.99999946%;text-align:end" x="126.207" y="292.88" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
     <tspan x="126.207" y="292.88" style="text-align:end" font-size="4.149">1 allocs/op</tspan>
@@ -40,18 +40,18 @@
   <text y="292.88" x="98.23" style="line-height:23.99999946%;text-align:end" transform="translate(0 -265.78)" font-weight="400" font-size="4.939" letter-spacing="0" word-spacing="0" text-anchor="end" fill="#333" stroke-width=".265">
     <tspan style="text-align:end" y="292.88" x="98.23" font-size="4.149">40 B/op</tspan>
   </text>
-  <path d="M138.67 12.994l-.013.002a.304.304 0 00-.26.15l-1.049 1.816-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.049-1.816-1.048-1.815a.304.304 0 00-.234-.15l-.015-.002a.06.06 0 00-.003 0z" style="solid-color:#000" color="#000" stroke-width=".034"/>
-  <path style="solid-color:#000" d="M138.67 13.061a.238.238 0 00-.216.119l-1.048 1.815-1.048 1.816a.24.24 0 00.205.355h4.193c.18 0 .295-.2.205-.355l-1.048-1.816-1.048-1.815a.237.237 0 00-.194-.119z" color="#000" fill="#fff" stroke-width=".034"/>
-  <path style="solid-color:#000" d="M138.668 13.128a.17.17 0 00-.156.085l-1.048 1.816-1.048 1.815a.17.17 0 00.147.255h4.193a.17.17 0 00.147-.255l-1.048-1.815-1.048-1.816a.17.17 0 00-.14-.085z" color="#000" stroke-width=".034"/>
-  <path d="M140.756 16.93h-4.192l1.048-1.816 1.048-1.816 1.048 1.816z" fill="#fc0" stroke-width=".034"/>
+  <path d="M138.67 12.994l-.013.002a.304.304 0 00-.26.15l-1.049 1.816-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.049-1.816-1.048-1.815a.304.304 0 00-.234-.15l-.015-.002a.06.06 0 00-.003 0z" style="solid-color:#000" color="#000"/>
+  <path style="solid-color:#000" d="M138.67 13.061a.238.238 0 00-.216.119l-1.048 1.815-1.048 1.816a.24.24 0 00.205.355h4.193c.18 0 .295-.2.205-.355l-1.048-1.816-1.048-1.815a.237.237 0 00-.194-.119z" color="#000" fill="#fff"/>
+  <path style="solid-color:#000" d="M138.668 13.128a.17.17 0 00-.156.085l-1.048 1.816-1.048 1.815a.17.17 0 00.147.255h4.193a.17.17 0 00.147-.255l-1.048-1.815-1.048-1.816a.17.17 0 00-.14-.085z" color="#000"/>
+  <path d="M140.756 16.93h-4.192l1.048-1.816 1.048-1.816 1.048 1.816z" fill="#fc0"/>
   <g transform="translate(136.025 12.752) scale(.03354)">
     <circle r="8.817" cy="111.117" cx="78.564"/>
     <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>
   </g>
-  <path style="solid-color:#000" d="M138.67 23.28l-.013.002a.304.304 0 00-.26.15l-1.049 1.816-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.049-1.816-1.048-1.815a.304.304 0 00-.234-.15l-.015-.002a.06.06 0 00-.003 0z" color="#000" stroke-width=".034"/>
-  <path d="M138.67 23.347a.238.238 0 00-.216.119l-1.048 1.815-1.048 1.816a.24.24 0 00.205.355h4.193c.18 0 .295-.2.205-.355l-1.048-1.816-1.048-1.815a.237.237 0 00-.194-.119z" style="solid-color:#000" color="#000" fill="#fff" stroke-width=".034"/>
-  <path d="M138.668 23.414a.17.17 0 00-.156.085l-1.048 1.816-1.048 1.815a.17.17 0 00.147.255h4.193a.17.17 0 00.147-.255l-1.048-1.815-1.048-1.816a.17.17 0 00-.14-.085z" style="solid-color:#000" color="#000" stroke-width=".034"/>
-  <path d="M140.756 27.215h-4.192l1.048-1.815 1.048-1.816 1.048 1.816z" fill="#fc0" stroke-width=".034"/>
+  <path style="solid-color:#000" d="M138.67 23.28l-.013.002a.304.304 0 00-.26.15l-1.049 1.816-1.048 1.816a.308.308 0 00.264.456h4.192c.23 0 .378-.258.264-.456l-1.049-1.816-1.048-1.815a.304.304 0 00-.234-.15l-.015-.002a.06.06 0 00-.003 0z" color="#000"/>
+  <path d="M138.67 23.347a.238.238 0 00-.216.119l-1.048 1.815-1.048 1.816a.24.24 0 00.205.355h4.193c.18 0 .295-.2.205-.355l-1.048-1.816-1.048-1.815a.237.237 0 00-.194-.119z" style="solid-color:#000" color="#000" fill="#fff"/>
+  <path d="M138.668 23.414a.17.17 0 00-.156.085l-1.048 1.816-1.048 1.815a.17.17 0 00.147.255h4.193a.17.17 0 00.147-.255l-1.048-1.815-1.048-1.816a.17.17 0 00-.14-.085z" style="solid-color:#000" color="#000"/>
+  <path d="M140.756 27.215h-4.192l1.048-1.815 1.048-1.816 1.048 1.816z" fill="#fc0"/>
   <g transform="translate(136.025 23.038) scale(.03354)">
     <circle cx="78.564" cy="111.117" r="8.817"/>
     <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>

--- a/cbor/v2.2.0/cbor_speed_comparison_barchart.svg
+++ b/cbor/v2.2.0/cbor_speed_comparison_barchart.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="746" height="250" viewBox="0 0 197.379 66.146" font-family="&quot;SF Pro Text&quot;,Inter,&quot;Segoe UI&quot;,Roboto,&quot;Noto Sans&quot;,&quot;Droid Sans&quot;,&quot;Liberation Sans&quot;,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="746" height="250" viewBox="0 0 197.379 66.146" font-family="SF Pro Text,Inter,Segoe UI,Roboto,Noto Sans,Droid Sans,Liberation Sans,Arimo,Arial,Oxygen,Ubuntu,Cantarell,sans-serif">
   <path fill="#fff" stroke="#fff" stroke-width=".426" d="M.213.213h196.953v65.719H.213z"/>
-  <path fill="#999" stroke-width=".085" stroke-linejoin="round" d="M119.484 42.855h.265V46.1h-.265z"/>
+  <path fill="#999" d="M119.484 42.855h.265V46.1h-.265z"/>
   <text y="242.935" x=".066" style="line-height:23.99999946%" transform="matrix(1.00162 0 0 .99839 0 -230.854)" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
     <tspan y="242.935" x=".066" font-size="3.874" fill="#666">Using Go structs with example data from RFC 8392 Appendix A.1</tspan>
   </text>
@@ -12,11 +12,11 @@
   </text>
   <path fill="#4285f4" stroke="#fff" stroke-width=".339" d="M-62.498-360.094h3.894v3.894h-3.894z" transform="matrix(1 0 0 .99678 204.22 378.167)"/>
   <text y="-356.793" x="-56.591" style="line-height:23.99999946%" font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 204.22 378.167)">
-    <tspan y="-356.793" x="-56.591" font-weight="600" font-size="4.24" fill="#4080ff">fxamacker/cbor 2.2</tspan>
+    <tspan y="-356.793" x="-56.591" font-weight="600" font-size="4.24" fill="#2060c0">fxamacker/cbor 2.2</tspan>
   </text>
   <path fill="#db4437" stroke="#fff" stroke-width=".339" d="M-62.272-349.472h3.894v3.894h-3.894z" transform="matrix(1 0 0 .99678 203.994 386.754)"/>
   <text y="-346.168" x="-56.489" style="line-height:23.99999946%" font-weight="400" font-size="5.644" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="matrix(1 0 0 .99678 203.994 386.754)">
-    <tspan y="-346.168" x="-56.489" font-weight="600" font-size="4.24" fill="#c04020">ugorji/go 1.1.7</tspan>
+    <tspan y="-346.168" x="-56.489" font-weight="600" font-size="4.24" fill="#a02000">ugorji/go 1.1.7</tspan>
   </text>
   <text style="line-height:1em" x="147.087" y="259.087" transform="matrix(1.00162 0 0 .99839 -.025 -230.854)" font-weight="400" font-size="5.635" letter-spacing="0" word-spacing="0" stroke-width=".264">
     <tspan x="147.087" y="259.087" style="line-height:50%" font-size="3.528" fill="#666">not using Go&apos;s unsafe pkg</tspan>
@@ -52,9 +52,9 @@
     <tspan style="text-align:end" y="255.533" x="40.944" font-size="3.528" text-anchor="end" fill="#4d4d4d">Encode CWT Claims</tspan>
   </text>
   <path fill="#4285f4" stroke="#e0e0e0" stroke-width=".347" stroke-linejoin="round" d="M43.285 18.765h34.338v4.914H43.285z"/>
-  <path fill="#999" stroke-width=".087" stroke-linejoin="round" d="M81.034 42.752h.265V46.1h-.265z"/>
+  <path fill="#999" d="M81.034 42.752h.265V46.1h-.265z"/>
   <path fill="#4285f4" stroke="#e0e0e0" stroke-width=".274" stroke-linejoin="round" d="M43.252 33.214h58.586v4.754H43.252z"/>
   <path fill="#db4436" stroke="#e0e0e0" stroke-width=".262" stroke-linejoin="round" d="M43.285 38.042h84.278v4.688H43.285z"/>
   <path fill="#db4436" stroke="#e0e0e0" stroke-width=".247" stroke-linejoin="round" d="M43.284 23.753h74.663v4.69H43.284z"/>
-  <path fill="#999" stroke-width=".248" stroke-linejoin="round" d="M42.847 18.633h.265V46.1h-.265z"/>
+  <path fill="#999" d="M42.847 18.633h.265V46.1h-.265z"/>
 </svg>


### PR DESCRIPTION
Display total size of malformed CBOR data used for decoding tests for resource exhaustion.
Make it easier to read names of CBOR libraries in the bar charts.

4 svg files updated.