### PR TITLE
Update cbor security comparison table

### DIFF
--- a/cbor/v2.2.0/cbor_security_table.svg
+++ b/cbor/v2.2.0/cbor_security_table.svg
@@ -57,8 +57,8 @@
     <circle r="8.817" cy="111.117" cx="78.564"/>
     <path d="M78.564 42.955a8.817 8.817 0 00-8.818 8.816l3.156 37.461a5.662 5.662 0 0011.325 0l3.154-37.46a8.817 8.817 0 00-8.817-8.817z"/>
   </g>
-  <path d="M8.31 37.748v-2.46l-.595.595-.307-.306 1.004-1.004h.23l1.004 1.004-.307.306-.595-.595v2.026h1.42v.434z" aria-label="↴" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" fill="green"/>
-  <text y="296.105" x="12.041" style="line-height:100%" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -257.312)">
-    <tspan y="296.105" x="12.041" font-size="4.145" fill="#4d4d4d">Only 1 bad msg (1 decode total) was needed to produce out of memory error.</tspan>
+  <path d="M8.31 37.219v-2.46l-.595.595-.307-.306 1.004-1.004h.23l1.004 1.004-.307.306-.595-.595v2.025h1.42v.435z" aria-label="↴" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" fill="green"/>
+  <text y="295.576" x="12.041" style="line-height:100%" font-weight="400" font-size="4.233" letter-spacing="0" word-spacing="0" stroke-width=".265" transform="translate(0 -257.312)">
+    <tspan y="295.576" x="12.041" font-size="4.145" fill="#4d4d4d">Only 1 bad msg (1 decode total) was needed to produce out of memory error.</tspan>
   </text>
 </svg>


### PR DESCRIPTION
Only 1 bad msg (1 decode total) was needed to produce out of memory error.

Moved it up 2px because some fonts truncate the letter "g" at the bottom depending on zoom level in the browser.